### PR TITLE
Allowing update params to be optional

### DIFF
--- a/apps/server/src/device/dtos/update-device.dto.ts
+++ b/apps/server/src/device/dtos/update-device.dto.ts
@@ -1,8 +1,8 @@
-import { IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 import { MAX_DESC_LEN, MAX_NAME_LEN, MIN_DESC_LEN, MIN_NAME_LEN } from '../../common/consts';
 
 export class UpdateDeviceDto {
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   @MinLength(MIN_NAME_LEN)
   @MaxLength(MAX_NAME_LEN)

--- a/apps/server/src/image/dtos/update-image.dto.ts
+++ b/apps/server/src/image/dtos/update-image.dto.ts
@@ -1,8 +1,8 @@
-import { IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 import { MAX_DESC_LEN, MAX_NAME_LEN, MIN_DESC_LEN, MIN_NAME_LEN } from '../../common/consts';
 
 export class UpdateImageDto {
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   @MinLength(MIN_NAME_LEN)
   @MaxLength(MAX_NAME_LEN)


### PR DESCRIPTION
When updating a device or image providing an `id` isn't required.