### PR TITLE
Adding deployments CRUD

### DIFF
--- a/apps/server/src/deployment/deployment.controller.spec.ts
+++ b/apps/server/src/deployment/deployment.controller.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeploymentController } from './deployment.controller';
+import { DeploymentService } from './deployment.service';
+import { CreateDeploymentDto } from './dtos/create-deployment.dto';
+import { Deployment, DeploymentState } from './entities/deployment.entity';
+
+describe('DeploymentController', () => {
+  let controller: DeploymentController;
+  let service: DeploymentService;
+
+  const mockDeployment: Deployment = {
+    uuid: 'uuid',
+    state: DeploymentState.SCHEDULED,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  const mockDeploymentService = {
+    create: jest.fn(),
+    findAll: jest.fn()
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DeploymentController],
+      providers: [
+        {
+          provide: DeploymentService,
+          useValue: mockDeploymentService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DeploymentController>(DeploymentController);
+    service = module.get<DeploymentService>(DeploymentService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('POST /deployments', () => {
+    it('should create a new deployment', async () => {
+      const createDeploymentDto: CreateDeploymentDto = {
+        // deviceUuid: 'deviceUuid',
+        // imageVersionUuid: 'versionUuid'
+      };
+
+      mockDeploymentService.create.mockResolvedValue(mockDeployment);
+
+      const result = await controller.create(createDeploymentDto);
+      expect(result).toEqual(mockDeployment);
+      expect(service.create).toHaveBeenCalledWith(createDeploymentDto);
+    });
+
+
+  });
+
+  describe('GET /deployments', () => {
+    it('should return an array of deployments', async () => {
+      const deployments = [mockDeployment];
+      mockDeploymentService.findAll.mockResolvedValue(deployments);
+
+      const result = await controller.findAll();
+      expect(result).toEqual(deployments);
+      expect(service.findAll).toHaveBeenCalled();
+    });
+
+    it('should return an empty array if no deployments are found', async () => {
+      mockDeploymentService.findAll.mockResolvedValue([]);
+
+      const result = await controller.findAll();
+      expect(result).toEqual([]);
+      expect(service.findAll).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/deployment/deployment.controller.ts
+++ b/apps/server/src/deployment/deployment.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { DeploymentService } from './deployment.service';
+import { Deployment } from './entities/deployment.entity';
+import { CreateDeploymentDto } from './dtos/create-deployment.dto';
+
+@Controller()
+export class DeploymentController {
+  constructor(private readonly deploymentService: DeploymentService) {}
+
+  @Post('deployments')
+  async create(@Body() createDeploymentDto: CreateDeploymentDto) {
+    return this.deploymentService.create(createDeploymentDto);
+  }
+
+  @Get('deployments')
+  findAll(): Promise<Deployment[]> {
+    return this.deploymentService.findAll();
+  }
+}

--- a/apps/server/src/deployment/deployment.module.ts
+++ b/apps/server/src/deployment/deployment.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DeploymentService } from './deployment.service';
+import { DeploymentController } from './deployment.controller';
+import { Deployment } from './entities/deployment.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Deployment])],
+  controllers: [DeploymentController],
+  providers: [DeploymentService],
+})
+export class DeploymentModule {}

--- a/apps/server/src/deployment/deployment.service.spec.ts
+++ b/apps/server/src/deployment/deployment.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DeploymentService } from './deployment.service';
+import { Deployment, DeploymentState } from './entities/deployment.entity';
+import { CreateDeploymentDto } from './dtos/create-deployment.dto';
+
+describe('DeploymentService', () => {
+  let service: DeploymentService;
+  let repository: Repository<Deployment>;
+
+  const mockDeployment: Deployment = {
+    uuid: 'uuid',
+    state: DeploymentState.SCHEDULED,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeploymentService,
+        {
+          provide: getRepositoryToken(Deployment),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DeploymentService>(DeploymentService);
+    repository = module.get<Repository<Deployment>>(getRepositoryToken(Deployment));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should successfully create a deployment', async () => {
+      const createDeploymentDto: CreateDeploymentDto = {
+        // deviceUuid: 'deviceUuid',
+        // imageVersionUuid: 'versionUuid'
+      };
+
+      const expectedDeployment = {
+        ...mockDeployment,
+        state: DeploymentState.SCHEDULED
+      };
+
+      mockRepository.save.mockResolvedValue(expectedDeployment);
+
+      const result = await service.create(createDeploymentDto);
+      expect(result).toEqual(expectedDeployment);
+      expect(mockRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: DeploymentState.SCHEDULED
+        })
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of deployments', async () => {
+      mockRepository.find.mockResolvedValue([mockDeployment]);
+
+      const result = await service.findAll();
+      expect(result).toEqual([mockDeployment]);
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        order: { createdAt: 'DESC' }
+      });
+    });
+
+    it('should return an empty array when no deployments exist', async () => {
+      mockRepository.find.mockResolvedValue([]);
+
+      const result = await service.findAll();
+      expect(result).toEqual([]);
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        order: { createdAt: 'DESC' }
+      });
+    });
+  });
+}); 

--- a/apps/server/src/deployment/deployment.service.ts
+++ b/apps/server/src/deployment/deployment.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Logger } from '@nestjs/common';
+import { Deployment, DeploymentState } from './entities/deployment.entity';
+import { Repository } from 'typeorm';
+import { CreateDeploymentDto } from './dtos/create-deployment.dto';
+
+@Injectable()
+export class DeploymentService {
+  private readonly logger = new Logger(DeploymentService.name);
+
+  constructor(
+    @InjectRepository(Deployment)
+    private readonly deploymentRepository: Repository<Deployment>,
+  ) {}
+
+  async create(createDeploymentDto: CreateDeploymentDto): Promise<Deployment> {
+    const deployment = new Deployment();
+    deployment.state = DeploymentState.SCHEDULED;
+    this.logger.log(`Creating deployment: ${deployment.uuid}`);
+    return this.deploymentRepository.save(deployment);
+  }
+
+  async findAll(): Promise<Deployment[]> {
+    return this.deploymentRepository.find({
+      order: {
+        createdAt: 'DESC'
+      }
+    });
+  }
+}

--- a/apps/server/src/deployment/dtos/create-deployment.dto.ts
+++ b/apps/server/src/deployment/dtos/create-deployment.dto.ts
@@ -1,0 +1,2 @@
+export class CreateDeploymentDto {
+}

--- a/apps/server/src/deployment/entities/deployment.entity.ts
+++ b/apps/server/src/deployment/entities/deployment.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  CreateDateColumn,
+} from 'typeorm';
+
+export enum DeploymentState {
+  FINISHED, // finished successfully
+  ERROR, // failed
+  WARNING, // still runing with warnings
+  RUNNING, // still running
+  CANCELED, // cancelled
+  CANCELING, // in cancelling state and waiting for cancel confirmation
+  RETRIEVED, // send to device
+  DOWNLOAD, // device has started downloading
+  SCHEDULED, // scheduled in a rollout but not active
+  CANCEL_REJECTED, // cancelletaion rejected by device
+  DOWNLOADED, // image has been downloaded and waiting to update
+  WAIT_FOR_CONFIRMATION // deployment waiting to be confirmed
+}
+
+@Entity()
+export class Deployment {
+  @PrimaryGeneratedColumn('uuid')
+  uuid: string;
+
+  @Column()
+  state: DeploymentState;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Why?

Towards https://github.com/DispatchOTA/dispatch/issues/14

Wires up basic deployment CRUD

## How?
- Adds entity with a `state`
- Can only create and list deployments
- Will follow up with associating them to devices and image versions.