### PR TITLE
Linking deployment to image version

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -4,6 +4,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { ENV_DEVELOPMENT, envValidationSchema } from './common';
 import { DeviceModule } from './device/device.module';
+import { ImageVersionModule } from './image-version/image-version.module';
+import { DeploymentModule } from './deployment/deployment.module';
 
 @Module({
   imports: [
@@ -22,6 +24,8 @@ import { DeviceModule } from './device/device.module';
       }),
     }),
     DeviceModule,
+    ImageVersionModule,
+    DeploymentModule,
   ],
   controllers: [AppController],
 })

--- a/apps/server/src/deployment/deployment.controller.spec.ts
+++ b/apps/server/src/deployment/deployment.controller.spec.ts
@@ -23,6 +23,22 @@ describe('DeploymentController', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       deployments: []
+    },
+    imageVersion: {
+      uuid: 'versionUuid',
+      id: 'versionId',
+      description: 'test version',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      image: {
+        uuid: 'imageUuid',
+        id: 'imageId',
+        description: 'test image',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        versions: []
+      },
+      deployments: []
     }
   };
 
@@ -54,7 +70,7 @@ describe('DeploymentController', () => {
     it('should create a new deployment', async () => {
       const createDeploymentDto: CreateDeploymentDto = {
         deviceUuid: 'deviceUuid',
-        // imageVersionUuid: 'versionUuid'
+        imageVersionUuid: 'versionUuid'
       };
 
       mockDeploymentService.create.mockResolvedValue(mockDeployment);
@@ -67,10 +83,22 @@ describe('DeploymentController', () => {
     it('should return 404 if device is not found', async () => {
       const createDeploymentDto: CreateDeploymentDto = {
         deviceUuid: 'nonexistentDeviceUuid',
-        // imageVersionUuid: 'versionUuid'
+        imageVersionUuid: 'versionUuid'
       };
 
       mockDeploymentService.create.mockRejectedValue(new NotFoundException('Device not found'));
+
+      await expect(controller.create(createDeploymentDto)).rejects.toThrow(NotFoundException);
+      expect(service.create).toHaveBeenCalledWith(createDeploymentDto);
+    });
+
+    it('should return 404 if image version is not found', async () => {
+      const createDeploymentDto: CreateDeploymentDto = {
+        deviceUuid: 'nonexistentDeviceUuid',
+        imageVersionUuid: 'versionUuid'
+      };
+
+      mockDeploymentService.create.mockRejectedValue(new NotFoundException('Image version not found'));
 
       await expect(controller.create(createDeploymentDto)).rejects.toThrow(NotFoundException);
       expect(service.create).toHaveBeenCalledWith(createDeploymentDto);

--- a/apps/server/src/deployment/deployment.service.spec.ts
+++ b/apps/server/src/deployment/deployment.service.spec.ts
@@ -22,7 +22,7 @@ describe('DeploymentService', () => {
     pollingTime: '60',
     createdAt: new Date(),
     updatedAt: new Date(),
-    deployments: []
+    deployments: [],
   };
 
   const mockImageVersion: ImageVersion = {
@@ -38,7 +38,8 @@ describe('DeploymentService', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       versions: []
-    }
+    },
+    deployments: [],
   };
 
   const mockDeployment: Deployment = {
@@ -46,7 +47,8 @@ describe('DeploymentService', () => {
     state: DeploymentState.SCHEDULED,
     createdAt: new Date(),
     updatedAt: new Date(),
-    device: mockDevice
+    device: mockDevice,
+    imageVersion: mockImageVersion,
   };
 
   const mockDeploymentRepository = {
@@ -98,7 +100,7 @@ describe('DeploymentService', () => {
   describe('create', () => {
     const createDeploymentDto: CreateDeploymentDto = {
       deviceUuid: 'deviceUuid',
-      // imageVersionUuid: 'versionUuid'
+      imageVersionUuid: 'versionUuid'
     };
 
     it('should successfully create a deployment', async () => {
@@ -112,9 +114,13 @@ describe('DeploymentService', () => {
       expect(deviceRepository.findOne).toHaveBeenCalledWith({
         where: { uuid: createDeploymentDto.deviceUuid }
       });
+      expect(imageVersionRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: createDeploymentDto.imageVersionUuid }
+      });
       expect(deploymentRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           device: mockDevice,
+          imageVersion: mockImageVersion,
           state: DeploymentState.SCHEDULED
         })
       );
@@ -128,6 +134,22 @@ describe('DeploymentService', () => {
       
       expect(deviceRepository.findOne).toHaveBeenCalledWith({
         where: { uuid: createDeploymentDto.deviceUuid }
+      });
+      expect(deploymentRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException if image version is not found', async () => {
+      mockDeviceRepository.findOne.mockResolvedValue(mockDevice);
+      mockImageVersionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.create(createDeploymentDto))
+        .rejects.toThrow(NotFoundException);
+      
+      expect(deviceRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: createDeploymentDto.deviceUuid }
+      });
+      expect(imageVersionRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: createDeploymentDto.imageVersionUuid }
       });
       expect(deploymentRepository.save).not.toHaveBeenCalled();
     });

--- a/apps/server/src/deployment/deployment.service.ts
+++ b/apps/server/src/deployment/deployment.service.ts
@@ -29,8 +29,17 @@ export class DeploymentService {
       throw new NotFoundException(`Device not found`);
     }
 
+    const imageVersion = await this.imageVersionRepository.findOne({
+      where: { uuid: createDeploymentDto.imageVersionUuid }
+    });
+    if (!imageVersion) {
+      this.logger.error(`Image version not found: ${createDeploymentDto.imageVersionUuid}`);
+      throw new NotFoundException(`Image version not found`);
+    }
+
     const deployment = new Deployment();
     deployment.device = device;
+    deployment.imageVersion = imageVersion;
     deployment.state = DeploymentState.SCHEDULED;
     this.logger.log(`Creating deployment: ${deployment.uuid}`);
     return this.deploymentRepository.save(deployment);

--- a/apps/server/src/deployment/dtos/create-deployment.dto.ts
+++ b/apps/server/src/deployment/dtos/create-deployment.dto.ts
@@ -4,4 +4,8 @@ export class CreateDeploymentDto {
   @IsUUID()
   @IsNotEmpty()
   deviceUuid: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  imageVersionUuid: string;
 }

--- a/apps/server/src/deployment/entities/deployment.entity.ts
+++ b/apps/server/src/deployment/entities/deployment.entity.ts
@@ -1,3 +1,4 @@
+import { ImageVersion } from '../../image-version/entities/image-version.entity';
 import { Device } from '../../device/entities/device.entity';
 import {
   Entity,
@@ -40,4 +41,7 @@ export class Deployment {
 
   @ManyToOne(() => Device, (device) => device.deployments)
   device: Device;
+
+  @ManyToOne(() => ImageVersion, (imageVersion) => imageVersion.deployments)
+  imageVersion: ImageVersion;
 }

--- a/apps/server/src/device/device.controller.spec.ts
+++ b/apps/server/src/device/device.controller.spec.ts
@@ -19,6 +19,7 @@ describe('DeviceController', () => {
     pollingTime: '30',
     createdAt: new Date(),
     updatedAt: new Date(),
+    deployments: [],
   };
 
   const mockDeviceService = {

--- a/apps/server/src/device/device.module.ts
+++ b/apps/server/src/device/device.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DeviceService } from './device.service';
 import { DeviceController } from './device.controller';
 import { Device } from './entities/device.entity';
+import { Deployment } from '../deployment/entities/deployment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Device])],
+  imports: [TypeOrmModule.forFeature([Device, Deployment])],
   controllers: [DeviceController],
   providers: [DeviceService],
 })

--- a/apps/server/src/device/device.service.spec.ts
+++ b/apps/server/src/device/device.service.spec.ts
@@ -18,7 +18,8 @@ describe('DeviceService', () => {
     state: 'active',
     pollingTime: '30',
     createdAt: new Date(),
-    updatedAt: new Date()
+    updatedAt: new Date(),
+    deployments: [],
   };
 
   const mockRepository = {

--- a/apps/server/src/image-version/entities/image-version.entity.ts
+++ b/apps/server/src/image-version/entities/image-version.entity.ts
@@ -1,3 +1,4 @@
+import { Deployment } from '../../deployment/entities/deployment.entity';
 import { Image } from '../../image/entities/image.entity';
 import {
   Entity,
@@ -6,6 +7,7 @@ import {
   UpdateDateColumn,
   CreateDateColumn,
   ManyToOne,
+  OneToMany,
 } from 'typeorm';
 
 @Entity()
@@ -27,4 +29,7 @@ export class ImageVersion {
 
   @ManyToOne(() => Image, (image) => image.versions)
   image: Image;
+
+  @OneToMany(() => Deployment, (deployment) => deployment.imageVersion)
+  deployments: Deployment[];
 }

--- a/apps/server/src/image-version/image-version.controller.spec.ts
+++ b/apps/server/src/image-version/image-version.controller.spec.ts
@@ -25,6 +25,7 @@ describe('ImageVersionController', () => {
       updatedAt: new Date(),
       versions: [],
     },
+    deployments: [],
   };
 
   const mockImageVersionService = {

--- a/apps/server/src/image-version/image-version.module.ts
+++ b/apps/server/src/image-version/image-version.module.ts
@@ -3,9 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ImageVersionService } from './image-version.service';
 import { ImageVersionController } from './image-version.controller';
 import { ImageVersion } from './entities/image-version.entity';
+import { Deployment } from '../deployment/entities/deployment.entity';
+import { Image } from '../image/entities/image.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ImageVersion])],
+  imports: [TypeOrmModule.forFeature([ImageVersion, Image, Deployment])],
   controllers: [ImageVersionController],
   providers: [ImageVersionService],
 })

--- a/apps/server/src/image-version/image-version.service.spec.ts
+++ b/apps/server/src/image-version/image-version.service.spec.ts
@@ -28,7 +28,8 @@ describe('ImageVersionService', () => {
     description: 'A test image version',
     createdAt: new Date(),
     updatedAt: new Date(),
-    image: mockImage
+    image: mockImage,
+    deployments: [],
   };
 
   const mockImageVersionRepository = {


### PR DESCRIPTION
## Why?

Towards https://github.com/DispatchOTA/dispatch/issues/14

Links deployments to image versions

## How?
- Sets up associations
- Adds image version id to DTO
- Checks for integrity before creation
- Updates specs
- Fixes imports