### PR TITLE
List deployments on device

### DIFF
--- a/apps/server/src/device/device.controller.ts
+++ b/apps/server/src/device/device.controller.ts
@@ -25,6 +25,11 @@ export class DeviceController {
     return this.deviceService.findOne(params.uuid);
   }
 
+  @Get('devices/:uuid/deployments')
+  async findDeployments(@Param() params: UUIDParamDto) {
+    return this.deviceService.findDeployments(params.uuid);
+  }
+
   @Put('devices/:uuid')
   async update(@Param() params: UUIDParamDto, @Body() updateDeviceDto: UpdateDeviceDto) {
     return this.deviceService.update(params.uuid, updateDeviceDto);

--- a/apps/server/src/device/device.service.spec.ts
+++ b/apps/server/src/device/device.service.spec.ts
@@ -6,6 +6,7 @@ import { Device } from './entities/device.entity';
 import { CreateDeviceDto } from './dtos/create-device.dto';
 import { UpdateDeviceDto } from './dtos/update-device.dto';
 import { NotFoundException } from '@nestjs/common';
+import { DeploymentState } from '../deployment/entities/deployment.entity';
 
 describe('DeviceService', () => {
   let service: DeviceService;
@@ -157,6 +158,76 @@ describe('DeviceService', () => {
       await expect(service.delete('uuid')).rejects.toThrow(NotFoundException);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
         where: { uuid: 'uuid' }
+      });
+    });
+  });
+
+  describe('findDeployments', () => {
+    it('should return deployments for a device', async () => {
+      const mockDeployments = [
+        {
+          uuid: 'deployment-uuid-1',
+          state: DeploymentState.SCHEDULED,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          device: mockDevice,
+          imageVersion: {
+            uuid: 'version-uuid',
+            id: 'version-id',
+            description: 'test version',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            image: {
+              uuid: 'image-uuid',
+              id: 'image-id',
+              description: 'test image',
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              versions: []
+            },
+            deployments: []
+          }
+        }
+      ];
+
+      const deviceWithDeployments = {
+        ...mockDevice,
+        deployments: mockDeployments
+      };
+
+      mockRepository.findOne.mockResolvedValue(deviceWithDeployments);
+
+      const result = await service.findDeployments('uuid');
+      expect(result).toEqual(mockDeployments);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: 'uuid' },
+        relations: ['deployments']
+      });
+    });
+
+    it('should return empty array if device has no deployments', async () => {
+      const deviceWithNoDeployments = {
+        ...mockDevice,
+        deployments: []
+      };
+
+      mockRepository.findOne.mockResolvedValue(deviceWithNoDeployments);
+
+      const result = await service.findDeployments('uuid');
+      expect(result).toEqual([]);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: 'uuid' },
+        relations: ['deployments']
+      });
+    });
+
+    it('should throw NotFoundException when device is not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findDeployments('uuid')).rejects.toThrow(NotFoundException);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { uuid: 'uuid' },
+        relations: ['deployments']
       });
     });
   });

--- a/apps/server/src/device/device.service.spec.ts
+++ b/apps/server/src/device/device.service.spec.ts
@@ -44,6 +44,7 @@ describe('DeviceService', () => {
 
     service = module.get<DeviceService>(DeviceService);
     repository = module.get<Repository<Device>>(getRepositoryToken(Device));
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -195,13 +196,20 @@ describe('DeviceService', () => {
         deployments: mockDeployments
       };
 
-      mockRepository.findOne.mockResolvedValue(deviceWithDeployments);
+      mockRepository.findOne.mockResolvedValueOnce(deviceWithDeployments);
 
       const result = await service.findDeployments('uuid');
       expect(result).toEqual(mockDeployments);
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
+      expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(mockRepository.findOne).toHaveBeenLastCalledWith({
         where: { uuid: 'uuid' },
-        relations: ['deployments']
+        relations: ['deployments'],
+        relationLoadStrategy: 'query',
+        order: {
+          deployments: {
+            createdAt: 'DESC'
+          }
+        }
       });
     });
 
@@ -211,23 +219,37 @@ describe('DeviceService', () => {
         deployments: []
       };
 
-      mockRepository.findOne.mockResolvedValue(deviceWithNoDeployments);
+      mockRepository.findOne.mockResolvedValueOnce(deviceWithNoDeployments);
 
       const result = await service.findDeployments('uuid');
       expect(result).toEqual([]);
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
+      expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(mockRepository.findOne).toHaveBeenLastCalledWith({
         where: { uuid: 'uuid' },
-        relations: ['deployments']
+        relations: ['deployments'],
+        relationLoadStrategy: 'query',
+        order: {
+          deployments: {
+            createdAt: 'DESC'
+          }
+        }
       });
     });
 
     it('should throw NotFoundException when device is not found', async () => {
-      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.findOne.mockResolvedValueOnce(null);
 
       await expect(service.findDeployments('uuid')).rejects.toThrow(NotFoundException);
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
+      expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(mockRepository.findOne).toHaveBeenLastCalledWith({
         where: { uuid: 'uuid' },
-        relations: ['deployments']
+        relations: ['deployments'],
+        relationLoadStrategy: 'query',
+        order: {
+          deployments: {
+            createdAt: 'DESC'
+          }
+        }
       });
     });
   });

--- a/apps/server/src/device/device.service.ts
+++ b/apps/server/src/device/device.service.ts
@@ -44,6 +44,12 @@ export class DeviceService {
     const device = await this.deviceRepository.findOne({
       where: { uuid },
       relations: ['deployments'],
+      relationLoadStrategy: 'query',
+      order: {
+        deployments: {
+          createdAt: 'DESC'
+        }
+      }
     });
     if (!device) {
       this.logger.error(`Device not found: ${uuid}`);

--- a/apps/server/src/device/device.service.ts
+++ b/apps/server/src/device/device.service.ts
@@ -40,6 +40,18 @@ export class DeviceService {
     });
   }
 
+  async findDeployments(uuid: string) {
+    const device = await this.deviceRepository.findOne({
+      where: { uuid },
+      relations: ['deployments'],
+    });
+    if (!device) {
+      this.logger.error(`Device not found: ${uuid}`);
+      throw new NotFoundException('Device not found');
+    }
+    return device.deployments;
+  }
+
   async update(uuid: string, updateDeviceDto: UpdateDeviceDto): Promise<Device> {
     const device = await this.findOne(uuid);
     if (!device) {


### PR DESCRIPTION
## Why?

Towards https://github.com/DispatchOTA/dispatch/issues/14

Lists deployments sent to device

## How?
- Sets up new endpoint and service call
- Some validation
- Orders deployments by most recent
- Will follow up with image version