### PR TITLE
Removing delete operations

### DIFF
--- a/apps/server/src/device/device.controller.spec.ts
+++ b/apps/server/src/device/device.controller.spec.ts
@@ -196,24 +196,4 @@ describe('DeviceController', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
-
-  describe('DELETE /devices/:uuid', () => {
-    it('should delete a device and return success message', async () => {
-      mockDeviceService.delete.mockResolvedValue(undefined);
-
-      const result = await controller.delete({ uuid: 'uuid' });
-      expect(result).toEqual(new MessageDto('Device has been deleted'));
-      expect(service.delete).toHaveBeenCalledWith('uuid');
-    });
-
-    it('should return a 404 error if the device is not found', async () => {
-      mockDeviceService.delete.mockRejectedValue(
-        new NotFoundException('Device not found'),
-      );
-
-      await expect(controller.delete({ uuid: 'uuid' })).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-  });
 });

--- a/apps/server/src/device/device.controller.ts
+++ b/apps/server/src/device/device.controller.ts
@@ -34,10 +34,4 @@ export class DeviceController {
   async update(@Param() params: UUIDParamDto, @Body() updateDeviceDto: UpdateDeviceDto) {
     return this.deviceService.update(params.uuid, updateDeviceDto);
   }
-
-  @Delete('devices/:uuid')
-  async delete(@Param() params: UUIDParamDto): Promise<MessageDto> {
-    await this.deviceService.delete(params.uuid);
-    return new MessageDto('Device has been deleted');
-  }
 }

--- a/apps/server/src/device/device.service.spec.ts
+++ b/apps/server/src/device/device.service.spec.ts
@@ -141,28 +141,6 @@ describe('DeviceService', () => {
     });
   });
 
-  describe('delete', () => {
-    it('should delete a device', async () => {
-      mockRepository.findOne.mockResolvedValue(mockDevice);
-      mockRepository.delete.mockResolvedValue({ affected: 1 });
-
-      await service.delete('uuid');
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: 'uuid' }
-      });
-      expect(mockRepository.delete).toHaveBeenCalledWith('uuid');
-    });
-
-    it('should throw NotFoundException when device to delete is not found', async () => {
-      mockRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.delete('uuid')).rejects.toThrow(NotFoundException);
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: 'uuid' }
-      });
-    });
-  });
-
   describe('findDeployments', () => {
     it('should return deployments for a device', async () => {
       const mockDeployments = [

--- a/apps/server/src/device/device.service.ts
+++ b/apps/server/src/device/device.service.ts
@@ -69,14 +69,4 @@ export class DeviceService {
     this.logger.log(`Updating device: ${device.uuid}`);
     return this.deviceRepository.save(device);
   }
-
-  async delete(uuid: string): Promise<void> {
-    const device = await this.findOne(uuid);
-    if (!device) {
-      this.logger.error(`Device not found: ${uuid}`);
-      throw new NotFoundException('Device not found');
-    }
-    this.logger.log(`Deleted device: ${uuid}`);
-    await this.deviceRepository.delete(uuid);
-  }
 }

--- a/apps/server/src/image-version/image-version.controller.spec.ts
+++ b/apps/server/src/image-version/image-version.controller.spec.ts
@@ -138,32 +138,4 @@ describe('ImageVersionController', () => {
       await expect(controller.update({ imageUuid: 'imageUuid', versionUuid: 'versionUuid' }, updateImageVersionDto)).rejects.toThrow(NotFoundException);
     });
   });
-
-  describe('DELETE /images/:imageUuid/versions/:versionUuid', () => {
-    it('should delete a image version and return success message', async () => {
-      mockImageVersionService.delete.mockResolvedValue(undefined);
-
-      const result = await controller.delete({ imageUuid: 'imageUuid', versionUuid: 'versionUuid' });
-      expect(result).toEqual(new MessageDto('Image version has been deleted'));
-      expect(service.delete).toHaveBeenCalledWith('imageUuid', 'versionUuid');
-    });
-
-    it('should return a 404 error if the image is not found', async () => {
-      mockImageVersionService.delete.mockRejectedValue(
-        new NotFoundException('Image not found'),
-      );
-
-      await expect(controller.delete({ imageUuid: 'imageUuid', versionUuid: 'versionUuid' })).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-
-    it('should return a 404 error if the image version is not found', async () => {
-      mockImageVersionService.delete.mockRejectedValue(
-        new NotFoundException('Image version not found'),
-      );
-
-      await expect(controller.delete({ imageUuid: 'imageUuid', versionUuid: 'versionUuid' })).rejects.toThrow(NotFoundException);
-    });
-  });
 });

--- a/apps/server/src/image-version/image-version.controller.ts
+++ b/apps/server/src/image-version/image-version.controller.ts
@@ -28,10 +28,4 @@ export class ImageVersionController {
   ) {
     return this.imageVersionService.update(params.imageUuid, params.versionUuid, updateImageVersionDto);
   }
-
-  @Delete('images/:imageUuid/versions/:versionUuid')
-  async delete(@Param() params: ImageVersionParamDto): Promise<MessageDto> {
-    await this.imageVersionService.delete(params.imageUuid, params.versionUuid);
-    return new MessageDto('Image version has been deleted');
-  }
 }

--- a/apps/server/src/image-version/image-version.service.spec.ts
+++ b/apps/server/src/image-version/image-version.service.spec.ts
@@ -178,36 +178,4 @@ describe('ImageVersionService', () => {
         .rejects.toThrow(NotFoundException);
     });
   });
-
-  describe('delete', () => {
-    it('should delete an image version', async () => {
-      mockImageRepository.findOne.mockResolvedValue(mockImage);
-      mockImageVersionRepository.findOne.mockResolvedValue(mockImageVersion);
-      mockImageVersionRepository.delete.mockResolvedValue({ affected: 1 });
-
-      await service.delete('imageUuid', 'versionUuid');
-      expect(mockImageRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: 'imageUuid' }
-      });
-      expect(mockImageVersionRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: 'versionUuid', image: mockImage }
-      });
-      expect(mockImageVersionRepository.delete).toHaveBeenCalledWith('versionUuid');
-    });
-
-    it('should throw NotFoundException when image is not found', async () => {
-      mockImageRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.delete('imageUuid', 'versionUuid'))
-        .rejects.toThrow(NotFoundException);
-    });
-
-    it('should throw NotFoundException when image version is not found', async () => {
-      mockImageRepository.findOne.mockResolvedValue(mockImage);
-      mockImageVersionRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.delete('imageUuid', 'versionUuid'))
-        .rejects.toThrow(NotFoundException);
-    });
-  });
 }); 

--- a/apps/server/src/image-version/image-version.service.ts
+++ b/apps/server/src/image-version/image-version.service.ts
@@ -51,17 +51,6 @@ export class ImageVersionService {
     return this.imageVersionRepository.save(imageVersion);
   }
 
-  async delete(imageUuid: string, versionUuid: string): Promise<void> {
-    const image = await this.findImage(imageUuid);
-    const imageVersion = await this.imageVersionRepository.findOne({ where: { uuid: versionUuid, image } });
-    if (!imageVersion) {
-      this.logger.error(`Image version not found: ${versionUuid}`);
-      throw new NotFoundException('Image version not found');
-    }
-    this.logger.log(`Deleted image version: ${versionUuid}`);
-    await this.imageVersionRepository.delete(versionUuid);
-  }
-
   private async findImage(imageUuid: string): Promise<Image> {
     const image = await this.imageRepository.findOne({ where: { uuid: imageUuid } });
     if (!image) {

--- a/apps/server/src/image/image.controller.spec.ts
+++ b/apps/server/src/image/image.controller.spec.ts
@@ -126,24 +126,4 @@ describe('ImageController', () => {
       ).rejects.toThrow(NotFoundException);
     });
   });
-
-  describe('DELETE /images/:uuid', () => {
-    it('should delete a image and return success message', async () => {
-      mockImageService.delete.mockResolvedValue(undefined);
-
-      const result = await controller.delete({ uuid: 'uuid' });
-      expect(result).toEqual(new MessageDto('Image has been deleted'));
-      expect(service.delete).toHaveBeenCalledWith('uuid');
-    });
-
-    it('should return a 404 error if the image is not found', async () => {
-      mockImageService.delete.mockRejectedValue(
-        new NotFoundException('Image not found'),
-      );
-
-      await expect(controller.delete({ uuid: 'uuid' })).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-  });
 });

--- a/apps/server/src/image/image.controller.ts
+++ b/apps/server/src/image/image.controller.ts
@@ -29,10 +29,4 @@ export class ImageController {
   async update(@Param() params: UUIDParamDto, @Body() updateImageDto: UpdateImageDto) {
     return this.imageService.update(params.uuid, updateImageDto);
   }
-
-  @Delete('images/:uuid')
-  async delete(@Param() params: UUIDParamDto): Promise<MessageDto> {
-    await this.imageService.delete(params.uuid);
-    return new MessageDto('Image has been deleted');
-  }
 }

--- a/apps/server/src/image/image.service.spec.ts
+++ b/apps/server/src/image/image.service.spec.ts
@@ -144,48 +144,4 @@ describe('ImageService', () => {
       });
     });
   });
-
-  describe('delete', () => {
-    it('should delete an image', async () => {
-      mockRepository.findOne.mockResolvedValue(mockImage);
-      const mockTransactionalEntityManager = {
-        delete: jest.fn().mockResolvedValue({ affected: 1 })
-      };
-      mockRepository.manager.transaction = jest.fn().mockImplementation(async (callback) => {
-        await callback(mockTransactionalEntityManager);
-      });
-
-      await service.delete('uuid');
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: 'uuid' }
-      });
-      expect(mockTransactionalEntityManager.delete).toHaveBeenCalledWith(Image, 'uuid');
-    });
-
-    it('should throw NotFoundException when image to delete is not found', async () => {
-      mockRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.delete('uuid')).rejects.toThrow(NotFoundException);
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: 'uuid' }
-      });
-    });
-
-    it('should delete all image versions when deleting an image', async () => {
-      mockRepository.findOne.mockResolvedValue(mockImage);
-      const mockTransactionalEntityManager = {
-        delete: jest.fn().mockResolvedValue({ affected: 1 })
-      };
-      mockRepository.manager.transaction = jest.fn().mockImplementation(async (callback) => {
-        await callback(mockTransactionalEntityManager);
-      });
-
-      await service.delete('uuid');
-      expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: 'uuid' }
-      });
-      expect(mockTransactionalEntityManager.delete).toHaveBeenCalledWith(ImageVersion, { image: { uuid: 'uuid' } });
-      expect(mockTransactionalEntityManager.delete).toHaveBeenCalledWith(Image, 'uuid');
-    });
-  });
 }); 

--- a/apps/server/src/image/image.service.ts
+++ b/apps/server/src/image/image.service.ts
@@ -44,15 +44,6 @@ export class ImageService {
     return this.imageRepository.save(image);
   }
 
-  async delete(uuid: string): Promise<void> {
-    const image = await this.findImage(uuid);
-    this.logger.log(`Deleted image: ${uuid}`);
-    await this.imageRepository.manager.transaction(async (transactionalEntityManager) => {
-      await transactionalEntityManager.delete(ImageVersion, { image: { uuid: image.uuid } });
-      await transactionalEntityManager.delete(Image, image.uuid);
-    });
-  }
-
   private async findImage(uuid: string): Promise<Image> {
     const image = await this.imageRepository.findOne({ where: { uuid } });
     if (!image) {


### PR DESCRIPTION
## Why?

Deleting resources in this application has edge cases, e.g. what if we delete a device mid-deployment, or an image that has been deployed successfully to devices. There are conditions and product questions we'll need to answer before we can safely delete resources so let's remove them for now.

## How?
- Remove all operations
