### PR TITLE
Server/wire ddi service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Very much in Alpha.
 - [x] CRUD devices
 - [x] CRUD images
 - [x] CRUD image versions
+- [x] (DDI) wire up basic API
 - [ ] Set up object storage
 - [ ] Add artifact model to image versions
 - [ ] Link artifacts to objects
-- [ ] (DDI) wire up basic API
 - [ ] (DDI) poll deployments
 - [ ] (DDI) send deployment base
 - [ ] (DDI) deployment feedback

--- a/apps/server/src/ddi/ddi.controller.spec.ts
+++ b/apps/server/src/ddi/ddi.controller.spec.ts
@@ -1,16 +1,43 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DdiController } from './ddi.controller';
+import { DdiService } from './ddi.service';
 import { NotImplementedException } from '@nestjs/common';
+import { WorkspaceDeviceParams, WorkspaceDeviceDeploymentParams, WorkspaceDeviceImageVersionParams, WorkspaceDeviceImageVersionFilenameParams } from './dtos/path-params.dto';
 
 describe('DdiController', () => {
   let controller: DdiController;
+  let service: DdiService;
+
+  const mockWorkspaceId = 'workspace1';
+  const mockDeviceId = 'device1';
+  const mockDeploymentId = 'deployment1';
+  const mockImageVersionId = 'imageVersion1';
+  const mockFileName = 'file1';
+
+  const mockDdiService = {
+    getRoot: jest.fn(),
+    getInstalledDeployment: jest.fn(),
+    getDeploymentBase: jest.fn(),
+    postDeploymentFeedback: jest.fn(),
+    getArtifacts: jest.fn(),
+    downloadArtifact: jest.fn(),
+    downloadArtifactMD5: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DdiController],
+      providers: [
+        {
+          provide: DdiService,
+          useValue: mockDdiService,
+        },
+      ],
     }).compile();
 
     controller = module.get<DdiController>(DdiController);
+    service = module.get<DdiService>(DdiService);
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -18,8 +45,17 @@ describe('DdiController', () => {
   });
 
   describe('GET /', () => {
-    it('should throw NotImplementedException', () => {
-      expect(() => controller.getRoot()).toThrow(NotImplementedException);
+    it('should call service.getRoot with correct params', async () => {
+      const params: WorkspaceDeviceParams = {
+        workspaceId: mockWorkspaceId,
+        deviceId: mockDeviceId,
+      };
+
+      mockDdiService.getRoot.mockResolvedValue({ hello: 'world' });
+
+      const result = await controller.getRoot(params);
+      expect(result).toEqual({ hello: 'world' });
+      expect(service.getRoot).toHaveBeenCalledWith(mockWorkspaceId, mockDeviceId);
     });
   });
 
@@ -30,38 +66,100 @@ describe('DdiController', () => {
   });
 
   describe('GET /installedBase/:deploymentId', () => {
-    it('should throw NotImplementedException', () => {
-      expect(() => controller.getInstalledDeployment()).toThrow(NotImplementedException);
+    it('should call service.getInstalledDeployment with correct params', async () => {
+      const params: WorkspaceDeviceDeploymentParams = {
+        workspaceId: mockWorkspaceId,
+        deviceId: mockDeviceId,
+        deploymentId: mockDeploymentId,
+      };
+
+      mockDdiService.getInstalledDeployment.mockResolvedValue({ hello: 'world' });
+
+      const result = await controller.getInstalledDeployment(params);
+      expect(result).toEqual({ hello: 'world' });
+      expect(service.getInstalledDeployment).toHaveBeenCalledWith(mockWorkspaceId, mockDeviceId, mockDeploymentId);
     });
   });
 
   describe('GET /deploymentBase/:deploymentId', () => {
-    it('should throw NotImplementedException', () => {
-      expect(() => controller.getDeploymentBase()).toThrow(NotImplementedException);
+    it('should call service.getDeploymentBase with correct params', async () => {
+      const params: WorkspaceDeviceDeploymentParams = {
+        workspaceId: mockWorkspaceId,
+        deviceId: mockDeviceId,
+        deploymentId: mockDeploymentId,
+      };
+
+      mockDdiService.getDeploymentBase.mockResolvedValue({ hello: 'world' });
+
+      const result = await controller.getDeploymentBase(params);
+      expect(result).toEqual({ hello: 'world' });
+      expect(service.getDeploymentBase).toHaveBeenCalledWith(mockWorkspaceId, mockDeviceId, mockDeploymentId);
     });
   });
 
   describe('POST /deploymentBase/:deploymentId/feedback', () => {
-    it('should throw NotImplementedException', () => {
-      expect(() => controller.postDeploymentFeedback()).toThrow(NotImplementedException);
+    it('should call service.postDeploymentFeedback with correct params', async () => {
+      const params: WorkspaceDeviceDeploymentParams = {
+        workspaceId: mockWorkspaceId,
+        deviceId: mockDeviceId,
+        deploymentId: mockDeploymentId,
+      };
+
+      mockDdiService.postDeploymentFeedback.mockResolvedValue({ hello: 'world' });
+
+      const result = await controller.postDeploymentFeedback(params);
+      expect(result).toEqual({ hello: 'world' });
+      expect(service.postDeploymentFeedback).toHaveBeenCalledWith(mockWorkspaceId, mockDeviceId, mockDeploymentId);
     });
   });
 
   describe('GET /softwaremodules/:imageVersionId/artifacts', () => {
-    it('should throw NotImplementedException', () => {
-      expect(() => controller.getArtifacts()).toThrow(NotImplementedException);
+    it('should call service.getArtifacts with correct params', async () => {
+      const params: WorkspaceDeviceImageVersionParams = {
+        workspaceId: mockWorkspaceId,
+        deviceId: mockDeviceId,
+        imageVersionId: mockImageVersionId,
+      };
+
+      mockDdiService.getArtifacts.mockResolvedValue({ hello: 'world' });
+
+      const result = await controller.getArtifacts(params);
+      expect(result).toEqual({ hello: 'world' });
+      expect(service.getArtifacts).toHaveBeenCalledWith(mockWorkspaceId, mockDeviceId, mockImageVersionId);
     });
   });
 
   describe('GET /softwaremodules/:imageVersionId/artifacts/:fileName', () => {
-    it('should throw NotImplementedException', () => {
-      expect(() => controller.downloadArtifact()).toThrow(NotImplementedException);
+    it('should call service.downloadArtifact with correct params', async () => {
+      const params: WorkspaceDeviceImageVersionFilenameParams = {
+        workspaceId: mockWorkspaceId,
+        deviceId: mockDeviceId,
+        imageVersionId: mockImageVersionId,
+        fileName: mockFileName,
+      };
+
+      mockDdiService.downloadArtifact.mockResolvedValue({ hello: 'world' });
+
+      const result = await controller.downloadArtifact(params);
+      expect(result).toEqual({ hello: 'world' });
+      expect(service.downloadArtifact).toHaveBeenCalledWith(mockWorkspaceId, mockDeviceId, mockImageVersionId, mockFileName);
     });
   });
 
   describe('GET /softwaremodules/:imageVersionId/artifacts/:fileName.MD5SUM', () => {
-    it('should throw NotImplementedException', () => {
-      expect(() => controller.downloadArtifactMD5()).toThrow(NotImplementedException);
+    it('should call service.downloadArtifactMD5 with correct params', async () => {
+      const params: WorkspaceDeviceImageVersionFilenameParams = {
+        workspaceId: mockWorkspaceId,
+        deviceId: mockDeviceId,
+        imageVersionId: mockImageVersionId,
+        fileName: mockFileName,
+      };
+
+      mockDdiService.downloadArtifactMD5.mockResolvedValue({ hello: 'world' });
+
+      const result = await controller.downloadArtifactMD5(params);
+      expect(result).toEqual({ hello: 'world' });
+      expect(service.downloadArtifactMD5).toHaveBeenCalledWith(mockWorkspaceId, mockDeviceId, mockImageVersionId, mockFileName);
     });
   });
 

--- a/apps/server/src/ddi/ddi.controller.ts
+++ b/apps/server/src/ddi/ddi.controller.ts
@@ -1,11 +1,17 @@
-import { Controller, Get, NotImplementedException, Post, Put } from '@nestjs/common';
+import { Controller, Get, NotImplementedException, Param, Post, Put } from '@nestjs/common';
+import { WorkspaceDeviceDeploymentParams, WorkspaceDeviceImageVersionFilenameParams, WorkspaceDeviceImageVersionParams, WorkspaceDeviceParams } from './dtos/path-params.dto';
+import { DdiService } from './ddi.service';
 
 @Controller('ddi/:workspaceId/controller/v1/:deviceId')
 export class DdiController {
 
+  constructor(
+    private readonly ddiService: DdiService
+  ) {}
+
   @Get('')
-  getRoot() {
-    throw new NotImplementedException();
+  getRoot(@Param() params: WorkspaceDeviceParams) {
+    return this.ddiService.getRoot(params.workspaceId, params.deviceId);
   }
 
   @Put('/configData')
@@ -14,33 +20,33 @@ export class DdiController {
   }
 
   @Get('/installedBase/:deploymentId')
-  getInstalledDeployment() {
-    throw new NotImplementedException();
+  getInstalledDeployment(@Param() params: WorkspaceDeviceDeploymentParams) {
+    return this.ddiService.getInstalledDeployment(params.workspaceId, params.deviceId, params.deploymentId);
   }
 
   @Get('/deploymentBase/:deploymentId')
-  getDeploymentBase() {
-    throw new NotImplementedException();
+  getDeploymentBase(@Param() params: WorkspaceDeviceDeploymentParams) {
+    return this.ddiService.getDeploymentBase(params.workspaceId, params.deviceId, params.deploymentId);
   }
 
   @Post('/deploymentBase/:deploymentId/feedback')
-  postDeploymentFeedback() {
-    throw new NotImplementedException();
+  postDeploymentFeedback(@Param() params: WorkspaceDeviceDeploymentParams) {
+    return this.ddiService.postDeploymentFeedback(params.workspaceId, params.deviceId, params.deploymentId);
   }
 
   @Get('/softwaremodules/:imageVersionId/artifacts')
-  getArtifacts() {
-    throw new NotImplementedException();
+  getArtifacts(@Param() params: WorkspaceDeviceImageVersionParams) {
+    return this.ddiService.getArtifacts(params.workspaceId, params.deviceId, params.imageVersionId);
   }
 
   @Get('/softwaremodules/:imageVersionId/artifacts/:fileName')
-  downloadArtifact() {
-    throw new NotImplementedException();
+  downloadArtifact(@Param() params: WorkspaceDeviceImageVersionFilenameParams) {
+    return this.ddiService.downloadArtifact(params.workspaceId, params.deviceId, params.imageVersionId, params.fileName);
   }
 
   @Get('/softwaremodules/:imageVersionId/artifacts/:fileName.MD5SUM')
-  downloadArtifactMD5() {
-    throw new NotImplementedException();
+  downloadArtifactMD5(@Param() params: WorkspaceDeviceImageVersionFilenameParams) {
+    return this.ddiService.downloadArtifactMD5(params.workspaceId, params.deviceId, params.imageVersionId, params.fileName);
   }
 
   @Get('/cancelAction/:deploymentId')

--- a/apps/server/src/ddi/ddi.module.ts
+++ b/apps/server/src/ddi/ddi.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { DdiController } from './ddi.controller';
+import { DdiService } from './ddi.service';
 
 @Module({
-  controllers: [DdiController]
+  controllers: [DdiController],
+  providers: [DdiService]
 })
 export class DdiModule {}

--- a/apps/server/src/ddi/ddi.service.spec.ts
+++ b/apps/server/src/ddi/ddi.service.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DdiService } from './ddi.service';
+import { Deployment } from '../deployment/entities/deployment.entity';
+import { Logger, NotImplementedException } from '@nestjs/common';
+
+describe('DdiService', () => {
+  let service: DdiService;
+  let repository: Repository<Deployment>;
+
+  const mockDeploymentRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockWorkspaceId = 'workspace1';
+  const mockDeviceId = 'device1';
+  const mockDeploymentId = 'deployment1';
+  const mockImageVersionId = 'imageVersion1';
+  const mockFileName = 'file1';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DdiService,
+        {
+          provide: getRepositoryToken(Deployment),
+          useValue: mockDeploymentRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DdiService>(DdiService);
+    repository = module.get<Repository<Deployment>>(getRepositoryToken(Deployment));
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getRoot', () => {
+    it('should return hello world object', async () => {
+      const result = await service.getRoot(mockWorkspaceId, mockDeviceId);
+      expect(result).toEqual({ hello: 'world' });
+    });
+  });
+
+  describe('getInstalledDeployment', () => {
+    it('should return hello world object', async () => {
+      const result = await service.getInstalledDeployment(mockWorkspaceId, mockDeviceId, mockDeploymentId);
+      expect(result).toEqual({ hello: 'world' });
+    });
+  });
+
+  describe('getDeploymentBase', () => {
+    it('should return hello world object', async () => {
+      const result = await service.getDeploymentBase(mockWorkspaceId, mockDeviceId, mockDeploymentId);
+      expect(result).toEqual({ hello: 'world' });
+    });
+  });
+
+  describe('postDeploymentFeedback', () => {
+    it('should return hello world object', async () => {
+      const result = await service.postDeploymentFeedback(mockWorkspaceId, mockDeviceId, mockDeploymentId);
+      expect(result).toEqual({ hello: 'world' });
+    });
+  });
+
+  describe('getArtifacts', () => {
+    it('should return hello world object', async () => {
+      const result = await service.getArtifacts(mockWorkspaceId, mockDeviceId, mockImageVersionId);
+      expect(result).toEqual({ hello: 'world' });
+    });
+  });
+
+  describe('downloadArtifact', () => {
+    it('should return hello world object', async () => {
+      const result = await service.downloadArtifact(mockWorkspaceId, mockDeviceId, mockImageVersionId, mockFileName);
+      expect(result).toEqual({ hello: 'world' });
+    });
+  });
+
+  describe('downloadArtifactMD5', () => {
+    it('should return hello world object', async () => {
+      const result = await service.downloadArtifactMD5(mockWorkspaceId, mockDeviceId, mockImageVersionId, mockFileName);
+      expect(result).toEqual({ hello: 'world' });
+    });
+  });
+}); 

--- a/apps/server/src/ddi/ddi.service.ts
+++ b/apps/server/src/ddi/ddi.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Deployment } from '../deployment/entities/deployment.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class DdiService {
+  private readonly logger = new Logger(DdiService.name);
+
+  constructor(
+    @InjectRepository(Deployment)
+    private readonly deploymentRepository: Repository<Deployment>,
+  ) {}
+
+  async getRoot(
+    workspaceId: string,
+    deviceId: string,
+  ) {
+    return {
+      hello: 'world',
+    }
+  }
+
+  async getInstalledDeployment(
+    workspaceId: string,
+    deviceId: string,
+    deploymentId: string,
+  ) {
+    return {
+      hello: 'world',
+    }
+  }
+
+  async getDeploymentBase(
+    workspaceId: string,
+    deviceId: string,
+    deploymentId: string,
+  ) {
+    return {
+      hello: 'world',
+    }
+  }
+
+  async postDeploymentFeedback(
+    workspaceId: string,
+    deviceId: string,
+    deploymentId: string,
+  ) {
+    return {
+      hello: 'world',
+    }
+  }
+
+  async getArtifacts(
+    workspaceId: string,
+    deviceId: string,
+    imageVersionId: string,
+  ) {
+    return {
+      hello: 'world',
+    }
+  }
+
+  async downloadArtifact(
+    workspaceId: string,
+    deviceId: string,
+    imageVersionId: string,
+    fileName: string,
+  ) {
+    return {
+      hello: 'world',
+    }
+  }
+
+  async downloadArtifactMD5(
+    workspaceId: string,
+    deviceId: string,
+    imageVersionId: string,
+    fileName: string,
+  ) {
+    return {
+      hello: 'world',
+    }
+  }
+}

--- a/apps/server/src/ddi/dtos/path-params.dto.ts
+++ b/apps/server/src/ddi/dtos/path-params.dto.ts
@@ -22,11 +22,7 @@ export class WorkspaceDeviceImageVersionParams extends WorkspaceDeviceParams {
   imageVersionId: string;
 }
 
-export class WorkspaceDeviceImageVersionFilenameParams extends WorkspaceDeviceParams{
-  @IsUUID()
-  @IsNotEmpty()
-  imageVersionId: string;
-
+export class WorkspaceDeviceImageVersionFilenameParams extends WorkspaceDeviceImageVersionParams {
   @IsString()
   @IsNotEmpty()
   fileName: string;

--- a/apps/server/src/ddi/dtos/path-params.dto.ts
+++ b/apps/server/src/ddi/dtos/path-params.dto.ts
@@ -1,0 +1,33 @@
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class WorkspaceDeviceParams {
+  @IsUUID()
+  @IsNotEmpty()
+  workspaceId: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  deviceId: string;
+}
+
+export class WorkspaceDeviceDeploymentParams extends WorkspaceDeviceParams {
+  @IsUUID()
+  @IsNotEmpty()
+  deploymentId: string;
+}
+
+export class WorkspaceDeviceImageVersionParams extends WorkspaceDeviceParams {
+  @IsUUID()
+  @IsNotEmpty()
+  imageVersionId: string;
+}
+
+export class WorkspaceDeviceImageVersionFilenameParams extends WorkspaceDeviceParams{
+  @IsUUID()
+  @IsNotEmpty()
+  imageVersionId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  fileName: string;
+}


### PR DESCRIPTION
## Why?

Wires the DDI controller to service for the endpoints we'll implement.

## How?
- Just returns hello world for now.
- Deployment cancellation and confirmation, and sending config data won't be implemented for a first pass so leaving them out.