### PR TITLE
Device defaults

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -7,6 +7,7 @@ import { DeviceModule } from './device/device.module';
 import { ImageVersionModule } from './image-version/image-version.module';
 import { DeploymentModule } from './deployment/deployment.module';
 import { DdiModule } from './ddi/ddi.module';
+import { ImageModule } from './image/image.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { DdiModule } from './ddi/ddi.module';
       }),
     }),
     DeviceModule,
+    ImageModule,
     ImageVersionModule,
     DeploymentModule,
     DdiModule,

--- a/apps/server/src/common/consts.ts
+++ b/apps/server/src/common/consts.ts
@@ -9,3 +9,5 @@ export const MIN_ID_LEN = 1;
 export const MAX_ID_LEN = 500;
 export const MIN_DESC_LEN = 0;
 export const MAX_DESC_LEN = 5000;
+
+export const DEFAULT_POLLING_TIME = '01:00:00'; // 1 hour

--- a/apps/server/src/ddi/ddi.module.ts
+++ b/apps/server/src/ddi/ddi.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { DdiController } from './ddi.controller';
 import { DdiService } from './ddi.service';
+import { Deployment } from '../deployment/entities/deployment.entity';
+import { Device } from '../device/entities/device.entity';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Deployment, Device]),
+  ],
   controllers: [DdiController],
   providers: [DdiService]
 })

--- a/apps/server/src/ddi/ddi.service.spec.ts
+++ b/apps/server/src/ddi/ddi.service.spec.ts
@@ -3,7 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { DdiService } from './ddi.service';
 import { Deployment } from '../deployment/entities/deployment.entity';
-import { Device } from '../device/entities/device.entity';
+import { Device, DeviceState } from '../device/entities/device.entity';
 import { NotFoundException } from '@nestjs/common';
 
 describe('DdiService', () => {
@@ -15,8 +15,8 @@ describe('DdiService', () => {
     uuid: 'uuid',
     id: 'device1',
     description: 'test device',
-    state: 'active',
-    pollingTime: '30',
+    state: DeviceState.UNKNOWN,
+    pollingTime: '01:00:00',
     createdAt: new Date(),
     updatedAt: new Date(),
     deployments: [],
@@ -71,7 +71,7 @@ describe('DdiService', () => {
       
       expect(result).toBeDefined();
       expect(result.config).toBeDefined();
-      expect(result.config.polling.sleep).toBe('00:10:00');
+      expect(result.config.polling.sleep).toBe('01:00:00');
       expect(deviceRepository.findOne).toHaveBeenCalledWith({
         where: { id: mockDeviceId }
       });

--- a/apps/server/src/ddi/ddi.service.ts
+++ b/apps/server/src/ddi/ddi.service.ts
@@ -106,21 +106,6 @@ export class DdiService {
     return device;
   }
 
-  private async findInFlightDeployment(deviceId: string) {
-    const deployment = await this.deploymentRepository.findOne({
-      where: {
-        device: {
-          id: deviceId,
-        },
-        state: DeploymentState.RUNNING,
-      },
-      order: {
-        createdAt: 'DESC',
-      },
-    });
-    return deployment;
-  }
-
   private buildRootResponse(
     pollingTime: string,
     requestConfig: boolean,

--- a/apps/server/src/deployment/deployment.controller.spec.ts
+++ b/apps/server/src/deployment/deployment.controller.spec.ts
@@ -4,6 +4,7 @@ import { DeploymentService } from './deployment.service';
 import { CreateDeploymentDto } from './dtos/create-deployment.dto';
 import { Deployment, DeploymentState } from './entities/deployment.entity';
 import { NotFoundException } from '@nestjs/common';
+import { DeviceState } from '../device/entities/device.entity';
 
 describe('DeploymentController', () => {
   let controller: DeploymentController;
@@ -18,7 +19,7 @@ describe('DeploymentController', () => {
       uuid: 'deviceUuid',
       id: 'deviceId',
       description: 'test device',
-      state: 'active',
+      state: DeviceState.UNKNOWN,
       pollingTime: '60',
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/apps/server/src/deployment/deployment.service.spec.ts
+++ b/apps/server/src/deployment/deployment.service.spec.ts
@@ -5,7 +5,7 @@ import { DeploymentService } from './deployment.service';
 import { Deployment, DeploymentState } from './entities/deployment.entity';
 import { CreateDeploymentDto } from './dtos/create-deployment.dto';
 import { NotFoundException } from '@nestjs/common';
-import { Device } from '../device/entities/device.entity';
+import { Device, DeviceState } from '../device/entities/device.entity';
 import { ImageVersion } from '../image-version/entities/image-version.entity';
 
 describe('DeploymentService', () => {
@@ -18,7 +18,7 @@ describe('DeploymentService', () => {
     uuid: 'deviceUuid',
     id: 'deviceId',
     description: 'test device',
-    state: 'active',
+    state: DeviceState.UNKNOWN,
     pollingTime: '60',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/apps/server/src/deployment/entities/deployment.entity.ts
+++ b/apps/server/src/deployment/entities/deployment.entity.ts
@@ -11,18 +11,18 @@ import {
 } from 'typeorm';
 
 export enum DeploymentState {
-  FINISHED, // finished successfully
-  ERROR, // failed
-  WARNING, // still runing with warnings
-  RUNNING, // still running
-  CANCELED, // cancelled
-  CANCELING, // in cancelling state and waiting for cancel confirmation
-  RETRIEVED, // send to device
-  DOWNLOAD, // device has started downloading
-  SCHEDULED, // scheduled in a rollout but not active
-  CANCEL_REJECTED, // cancelletaion rejected by device
-  DOWNLOADED, // image has been downloaded and waiting to update
-  WAIT_FOR_CONFIRMATION // deployment waiting to be confirmed
+  FINISHED = 'finished', // finished successfully
+  ERROR = 'error', // failed
+  WARNING = 'warning', // still runing with warnings
+  RUNNING = 'running', // still running
+  CANCELED = 'canceled', // cancelled
+  CANCELING = 'canceling', // in cancelling state and waiting for cancel confirmation
+  RETRIEVED = 'retrieved', // send to device
+  DOWNLOAD = 'download', // device has started downloading
+  SCHEDULED = 'scheduled', // scheduled in a rollout but not active
+  CANCEL_REJECTED = 'cancel_rejected', // cancelletaion rejected by device
+  DOWNLOADED = 'downloaded', // image has been downloaded and waiting to update
+  WAIT_FOR_CONFIRMATION = 'wait_for_confirmation', // deployment waiting to be confirmed
 }
 
 @Entity()

--- a/apps/server/src/device/device.controller.spec.ts
+++ b/apps/server/src/device/device.controller.spec.ts
@@ -3,7 +3,7 @@ import { DeviceController } from './device.controller';
 import { DeviceService } from './device.service';
 import { CreateDeviceDto } from './dtos/create-device.dto';
 import { UpdateDeviceDto } from './dtos/update-device.dto';
-import { Device } from './entities/device.entity';
+import { Device, DeviceState } from './entities/device.entity';
 import { MessageDto } from '../common/dtos/message.dto';
 import { NotFoundException } from '@nestjs/common';
 import { Deployment, DeploymentState } from '../deployment/entities/deployment.entity';
@@ -17,7 +17,7 @@ describe('DeviceController', () => {
     uuid: 'uuid',
     id: 'id',
     description: 'A test device',
-    state: 'active',
+    state: DeviceState.UNKNOWN,
     pollingTime: '30',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/apps/server/src/device/device.service.spec.ts
+++ b/apps/server/src/device/device.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { DeviceService } from './device.service';
-import { Device } from './entities/device.entity';
+import { Device, DeviceState } from './entities/device.entity';
 import { CreateDeviceDto } from './dtos/create-device.dto';
 import { UpdateDeviceDto } from './dtos/update-device.dto';
 import { NotFoundException } from '@nestjs/common';
@@ -16,7 +16,7 @@ describe('DeviceService', () => {
     uuid: 'uuid',
     id: 'id',
     description: 'A test device',
-    state: 'active',
+    state: DeviceState.UNKNOWN,
     pollingTime: '30',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/apps/server/src/device/device.service.ts
+++ b/apps/server/src/device/device.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Logger } from '@nestjs/common';
-import { Device } from './entities/device.entity';
+import { Device, DeviceState } from './entities/device.entity';
 import { Repository } from 'typeorm';
 import { UpdateDeviceDto } from './dtos/update-device.dto';
 import { CreateDeviceDto } from './dtos/create-device.dto';
+import { DEFAULT_POLLING_TIME } from '../common/consts';
 
 @Injectable()
 export class DeviceService {
@@ -19,6 +20,8 @@ export class DeviceService {
     const device = new Device();
     device.id = createDeviceDto.id;
     device.description = createDeviceDto.description;
+    device.pollingTime = DEFAULT_POLLING_TIME;
+    device.state = DeviceState.UNKNOWN;
     this.logger.log(`Creating device: ${device.uuid}`);
     return this.deviceRepository.save(device);
   }

--- a/apps/server/src/device/entities/device.entity.ts
+++ b/apps/server/src/device/entities/device.entity.ts
@@ -8,6 +8,13 @@ import {
   OneToMany,
 } from 'typeorm';
 
+export enum DeviceState {
+  UNKNOWN = 'unknown',
+  IN_SYNC = 'in_sync',
+  PENDING = 'pending',
+  ERROR = 'error',
+}
+
 @Entity()
 export class Device {
   @PrimaryGeneratedColumn('uuid')
@@ -20,7 +27,7 @@ export class Device {
   description: string;
 
   @Column()
-  state: string;
+  state: DeviceState;
 
   @Column()
   pollingTime: string;


### PR DESCRIPTION
## Why?

Adds default device state and returns device polling time in DDI APi

## How?
- Defines a default polling time and defaults to it with creating a device
- Defines a device state and default one when creating devices
- Changes int enums to string enums
- Also adds image module to app module