### PR TITLE
Adding request config column to device

### DIFF
--- a/apps/server/src/ddi/ddi.service.spec.ts
+++ b/apps/server/src/ddi/ddi.service.spec.ts
@@ -25,6 +25,7 @@ describe('DdiService', () => {
     description: 'test device',
     state: DeviceState.UNKNOWN,
     pollingTime: '01:00:00',
+    requestConfig: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     deployments: [],

--- a/apps/server/src/ddi/ddi.service.ts
+++ b/apps/server/src/ddi/ddi.service.ts
@@ -27,7 +27,7 @@ export class DdiService {
     const inFlightDeployment = null;
     return this.buildRootResponse(
       device.pollingTime,
-      false,
+      device.requestConfig,
       device,
       installedDeployment,
       inFlightDeployment,

--- a/apps/server/src/deployment/deployment.service.spec.ts
+++ b/apps/server/src/deployment/deployment.service.spec.ts
@@ -20,6 +20,7 @@ describe('DeploymentService', () => {
     description: 'test device',
     state: DeviceState.UNKNOWN,
     pollingTime: '60',
+    requestConfig: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     deployments: [],

--- a/apps/server/src/device/device.controller.spec.ts
+++ b/apps/server/src/device/device.controller.spec.ts
@@ -19,6 +19,7 @@ describe('DeviceController', () => {
     description: 'A test device',
     state: DeviceState.UNKNOWN,
     pollingTime: '30',
+    requestConfig: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     deployments: [],

--- a/apps/server/src/device/device.service.spec.ts
+++ b/apps/server/src/device/device.service.spec.ts
@@ -18,6 +18,7 @@ describe('DeviceService', () => {
     description: 'A test device',
     state: DeviceState.UNKNOWN,
     pollingTime: '30',
+    requestConfig: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     deployments: [],

--- a/apps/server/src/device/device.service.ts
+++ b/apps/server/src/device/device.service.ts
@@ -22,6 +22,7 @@ export class DeviceService {
     device.description = createDeviceDto.description;
     device.pollingTime = DEFAULT_POLLING_TIME;
     device.state = DeviceState.UNKNOWN;
+    device.requestConfig = false;
     this.logger.log(`Creating device: ${device.uuid}`);
     return this.deviceRepository.save(device);
   }

--- a/apps/server/src/device/entities/device.entity.ts
+++ b/apps/server/src/device/entities/device.entity.ts
@@ -1,3 +1,4 @@
+import { Exclude } from 'class-transformer';
 import { Deployment } from '../../deployment/entities/deployment.entity';
 import {
   Entity,
@@ -31,6 +32,10 @@ export class Device {
 
   @Column()
   pollingTime: string;
+
+  @Exclude()
+  @Column()
+  requestConfig: boolean;
 
   @CreateDateColumn()
   createdAt: Date;


### PR DESCRIPTION
## Why?

Adds column on device specifying whether we should request config attributes

## How?
- Defaults to false and isn't updated anywhere.
- Will update this when the config endpoint is implemented.