### PR TITLE
DDI polling deployments

### DIFF
--- a/apps/server/src/ddi/ddi.service.spec.ts
+++ b/apps/server/src/ddi/ddi.service.spec.ts
@@ -156,8 +156,6 @@ describe('DdiService', () => {
       });
     });
 
-    // put spec file here
-
     it('should throw NotFoundException when device does not exist', async () => {
       mockDeviceRepository.findOne.mockResolvedValue(null);
 

--- a/apps/server/src/ddi/ddi.service.spec.ts
+++ b/apps/server/src/ddi/ddi.service.spec.ts
@@ -2,10 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { DdiService } from './ddi.service';
-import { Deployment } from '../deployment/entities/deployment.entity';
+import { Deployment, DeploymentState } from '../deployment/entities/deployment.entity';
 import { Device, DeviceState } from '../device/entities/device.entity';
 import { NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { ImageVersion } from '../image-version/entities/image-version.entity';
 
 describe('DdiService', () => {
   let service: DdiService;
@@ -20,7 +21,7 @@ describe('DdiService', () => {
   const mockFileName = 'file1';
   const mockOrigin = 'http://localhost:3000';
   const mockDevice: Device = {
-    uuid: 'uuid',
+    uuid: mockDeviceId,
     id: 'device1',
     description: 'test device',
     state: DeviceState.UNKNOWN,
@@ -69,6 +70,8 @@ describe('DdiService', () => {
     deviceRepository = module.get<Repository<Device>>(getRepositoryToken(Device));
     configService = module.get<ConfigService>(ConfigService);
     jest.clearAllMocks();
+
+    mockConfigService.get.mockReturnValue(mockOrigin);
   });
 
   it('should be defined', () => {
@@ -76,18 +79,84 @@ describe('DdiService', () => {
   });
 
   describe('getRoot', () => {
-    it('should return root response with config when device exists', async () => {
+    it('should return root response with no links', async () => {
       mockDeviceRepository.findOne.mockResolvedValue(mockDevice);
+      mockDeploymentRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
 
       const result = await service.getRoot(mockWorkspaceId, mockDeviceId);
       
       expect(result).toBeDefined();
       expect(result.config).toBeDefined();
       expect(result.config.polling.sleep).toBe('01:00:00');
+      expect(result._links).toBeUndefined();
       expect(deviceRepository.findOne).toHaveBeenCalledWith({
         where: { uuid: mockDeviceId }
       });
     });
+
+    it('should include installedBase link when device has installed deployment', async () => {
+      mockDeviceRepository.findOne.mockResolvedValue(mockDevice);
+      const mockInstalledDeployment = {
+        uuid: 'installed-deployment-uuid',
+        state: DeploymentState.FINISHED,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        device: mockDevice,
+        imageVersion: null
+      };
+      mockDeploymentRepository.findOne
+        .mockResolvedValueOnce(mockInstalledDeployment) // for installed deployment
+        .mockResolvedValueOnce(null); // for in-flight deployment
+
+      const result = await service.getRoot(mockWorkspaceId, mockDeviceId);
+      
+      expect(result._links).toBeDefined();
+      expect(result._links!.installedBase).toBeDefined();
+      expect(result._links!.installedBase!.href).toBe(
+        `${mockOrigin}/ddi/${mockWorkspaceId}/controller/v1/${mockDeviceId}/installedBase/${mockInstalledDeployment.uuid}`
+      );
+      expect(result._links!.deploymentBase).toBeUndefined();
+      expect(deploymentRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          device: { uuid: mockDeviceId },
+          state: DeploymentState.FINISHED
+        },
+        order: { createdAt: 'DESC' }
+      });
+    });
+
+    it('should include deploymentBase link when device has in-flight deployment', async () => {
+      mockDeviceRepository.findOne.mockResolvedValue(mockDevice);
+      const mockInFlightDeployment = {
+        uuid: 'in-flight-deployment-uuid',
+        state: DeploymentState.RUNNING,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        device: mockDevice,
+        imageVersion: null
+      };
+      mockDeploymentRepository.findOne
+        .mockResolvedValueOnce(null) // for installed deployment
+        .mockResolvedValueOnce(mockInFlightDeployment); // for in-flight deployment
+
+      const result = await service.getRoot(mockWorkspaceId, mockDeviceId);
+      
+      expect(result._links).toBeDefined();
+      expect(result._links!.deploymentBase).toBeDefined();
+      expect(result._links!.deploymentBase!.href).toBe(
+        `${mockOrigin}/ddi/${mockWorkspaceId}/controller/v1/${mockDeviceId}/deploymentBase/${mockInFlightDeployment.uuid}`
+      );
+      expect(result._links!.installedBase).toBeUndefined();
+      expect(deploymentRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          device: { uuid: mockDeviceId },
+          state: DeploymentState.RUNNING
+        },
+        order: { createdAt: 'DESC' }
+      });
+    });
+
+    // put spec file here
 
     it('should throw NotFoundException when device does not exist', async () => {
       mockDeviceRepository.findOne.mockResolvedValue(null);
@@ -143,11 +212,119 @@ describe('DdiService', () => {
     });
   });
 
-  describe('link building', () => {
-    beforeEach(() => {
-      mockConfigService.get.mockReturnValue(mockOrigin);
+  describe('getDeviceOrThrow', () => {
+    it('should return device', async () => {
+      mockDeviceRepository.findOne.mockResolvedValue(mockDevice);
+      const result = await service.getDeviceOrThrow(mockDeviceId);
+      expect(result).toEqual(mockDevice);
     });
 
+    it('should throw NotFoundException when device does not exist', async () => {
+      mockDeviceRepository.findOne.mockResolvedValue(null);
+      await expect(service.getDeviceOrThrow(mockDeviceId))
+        .rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deployments', () => {
+    const mockImageVersion: ImageVersion = {
+      uuid: 'imageVersion1',
+      id: 'image1',
+      description: 'test image',
+      image: {
+        uuid: 'image1',
+        id: 'image1',
+        description: 'test image',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        versions: [],
+      },
+      deployments: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const mockDeployments: Deployment[] = [
+      {
+        uuid: 'deployment0', 
+        state: DeploymentState.SCHEDULED,
+        createdAt: new Date('2024-01-05'),
+        updatedAt: new Date('2024-01-05'),
+        device: mockDevice,
+        imageVersion: mockImageVersion,
+      },
+      {
+        uuid: 'deployment1',
+        state: DeploymentState.RUNNING,
+        createdAt: new Date('2024-01-02'),
+        updatedAt: new Date('2024-01-02'),
+        device: mockDevice,
+        imageVersion: mockImageVersion,
+      },
+      {
+        uuid: 'deployment2', 
+        state: DeploymentState.RUNNING,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        device: mockDevice,
+        imageVersion: mockImageVersion,
+      },
+      {
+        uuid: 'deployment3', 
+        state: DeploymentState.SCHEDULED,
+        createdAt: new Date('2024-01-03'),
+        updatedAt: new Date('2024-01-03'),
+        device: mockDevice,
+        imageVersion: mockImageVersion,
+      },
+      {
+        uuid: 'deployment4', 
+        state: DeploymentState.FINISHED,
+        createdAt: new Date('2024-01-04'),
+        updatedAt: new Date('2024-01-04'),
+        device: mockDevice,
+        imageVersion: mockImageVersion,
+      },
+      {
+        uuid: 'deployment5', 
+        state: DeploymentState.FINISHED,
+        createdAt: new Date('2024-01-03'),
+        updatedAt: new Date('2024-01-03'),
+        device: mockDevice,
+        imageVersion: mockImageVersion,
+      },
+    ];
+
+    describe('findInstalledDeployment', () => {
+      it('should return the most recent installed deployment', async () => {
+        mockDeploymentRepository.findOne.mockResolvedValue(mockDeployments[4]);
+        const result = await service.findInstalledDeployment(mockDeviceId);
+        expect(result).toEqual(mockDeployments[4]);
+      });
+
+      it('should return null when no installed deployment', async () => {
+        mockDeploymentRepository.findOne.mockResolvedValue(null);
+        const result = await service.findInstalledDeployment(mockDeviceId);
+        expect(result).toEqual(null);
+      });
+    });
+
+    describe('findInFlightDeployment', () => {
+      it('should return the most recent in flight deployment', async () => {
+        mockDeploymentRepository.findOne.mockResolvedValue(mockDeployments[1]);
+        const result = await service.findInFlightDeployment(mockDeviceId);
+        expect(result).toEqual(mockDeployments[1]);
+      });
+
+      it('should return null when no in flight deployment', async () => {
+        mockDeploymentRepository.findOne.mockResolvedValue(null);
+        const result = await service.findInFlightDeployment(mockDeviceId);
+        expect(result).toEqual(null);
+      });
+    });
+  });
+
+  describe('link building', () => {
     describe('buildConfigLink', () => {
       it('should build correct config link', () => {
         const link = service.buildConfigLink(mockDeviceId);


### PR DESCRIPTION
## Why?

Adds deployment links in DDI polling endpoint.

## How?
- Adds more test coverage for the links in the polling request
- Gets the most recently installed deployment for a device
- Gets the in-flight deployment for a device
- Adds the links to them if they exist
- Some small general tidying and testing