### PR TITLE
Tidy DDI helper and fix spec

### DIFF
--- a/apps/server/src/ddi/ddi.service.ts
+++ b/apps/server/src/ddi/ddi.service.ts
@@ -28,9 +28,9 @@ export class DdiService {
     return this.buildRootResponse(
       device.pollingTime,
       device.requestConfig,
-      device,
-      installedDeployment,
-      inFlightDeployment,
+      device.uuid,
+      installedDeployment?.uuid,
+      inFlightDeployment?.uuid,
     );
   }
 
@@ -141,9 +141,9 @@ export class DdiService {
   private buildRootResponse(
     pollingTime: string,
     requestConfig: boolean,
-    device: Device,
-    installedDeployment: Deployment | null,
-    inFlightDeployment: Deployment | null,
+    deviceId: string,
+    installedDeploymentId: string | undefined,
+    inFlightDeploymentId: string | undefined,
   ): RootDto {
     const root = new RootDto();
 
@@ -158,20 +158,20 @@ export class DdiService {
     const links = new LinksDto();
     if (requestConfig) {
       const link = new LinkDto();
-      link.href = this.buildConfigLink(device.uuid);
+      link.href = this.buildConfigLink(deviceId);
       links.configData = link;
     }
-    if (installedDeployment) {
+    if (installedDeploymentId) {
       const link = new LinkDto();
-      link.href = this.buildInstalledBaseLink(device.uuid, installedDeployment.uuid);
+      link.href = this.buildInstalledBaseLink(deviceId, installedDeploymentId);
       links.installedBase = link;
     }
-    if (inFlightDeployment) {
+    if (inFlightDeploymentId) {
       const link = new LinkDto();
-      link.href = this.buildDeploymentBaseLink(device.uuid, inFlightDeployment.uuid);
+      link.href = this.buildDeploymentBaseLink(deviceId, inFlightDeploymentId);
       links.deploymentBase = link;
     }
-    if (requestConfig || installedDeployment || inFlightDeployment) {
+    if (requestConfig || installedDeploymentId || inFlightDeploymentId) {
       root._links = links;
     }
     return root;

--- a/apps/server/src/deployment/deployment.controller.spec.ts
+++ b/apps/server/src/deployment/deployment.controller.spec.ts
@@ -21,6 +21,7 @@ describe('DeploymentController', () => {
       description: 'test device',
       state: DeviceState.UNKNOWN,
       pollingTime: '60',
+      requestConfig: false,
       createdAt: new Date(),
       updatedAt: new Date(),
       deployments: []


### PR DESCRIPTION
# Why?

Small tidying and fixing broken spec

# How?
- Only pass primitives to helpers
- Add missing attribute on mock