### PR TITLE
Transforming deployment into DDI DTO

### DIFF
--- a/apps/server/src/ddi/dtos/deployment-res.dto.ts
+++ b/apps/server/src/ddi/dtos/deployment-res.dto.ts
@@ -6,16 +6,7 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ArtifactDto } from './artifacts.res.dto';
-
-export enum StatusEnum {
-  CANCELED = 'canceled',
-  WARNING = 'warning',
-  ERROR = 'error',
-  FINISHED = 'finished',
-  DOWNLOAD = 'download',
-  DOWNLOADED = 'downloaded',
-  RUNNING = 'running',
-}
+import { DeploymentState } from '../../deployment/entities/deployment.entity';
 
 export enum DownloadUpdateEnum {
   SKIP = 'skip',
@@ -74,8 +65,21 @@ export class DeploymentDto {
 }
 
 export class ActionHistoryDto {
-  @IsEnum(StatusEnum)
-  status: StatusEnum;
+  @IsEnum({
+    FINISHED: 'finished',
+    ERROR: 'error',
+    WARNING: 'warning',
+    RUNNING: 'running',
+    CANCELED: 'canceled',
+    CANCELING: 'canceling',
+    RETRIEVED: 'retrieved',
+    DOWNLOAD: 'download',
+    SCHEDULED: 'scheduled',
+    CANCEL_REJECTED: 'cancel_rejected',
+    DOWNLOADED: 'downloaded',
+    WAIT_FOR_CONFIRMATION: 'wait_for_confirmation',
+  })
+  status: DeploymentState;
 
   @IsArray()
   @IsString({ each: true })

--- a/apps/server/src/deployment/entities/deployment.entity.spec.ts
+++ b/apps/server/src/deployment/entities/deployment.entity.spec.ts
@@ -1,0 +1,70 @@
+import { Deployment, DeploymentState } from './deployment.entity';
+import { DownloadUpdateEnum } from '../../ddi/dtos/deployment-res.dto';
+import { createMockDevice, createMockImageVersion } from '../../../test/factories';
+
+describe('Deployment', () => {
+  let deployment: Deployment;
+  const mockDevice = createMockDevice();
+  const mockImageVersion = createMockImageVersion();
+
+  beforeEach(() => {
+    deployment = new Deployment();
+    deployment.uuid = 'test-uuid';
+    deployment.state = DeploymentState.RUNNING;
+    deployment.device = mockDevice;
+    deployment.imageVersion = mockImageVersion;
+    deployment.createdAt = new Date();
+    deployment.updatedAt = new Date();
+  });
+
+  describe('getDownloadType', () => {
+    it('should return ATTEMPT', () => {
+      expect(deployment.getDownloadType()).toBe(DownloadUpdateEnum.ATTEMPT);
+    });
+  });
+
+  describe('getUpdateType', () => {
+    it('should return ATTEMPT', () => {
+      expect(deployment.getUpdateType()).toBe(DownloadUpdateEnum.ATTEMPT);
+    });
+  });
+
+  describe('getMaintenanceWindow', () => {
+    it('should return undefined', () => {
+      expect(deployment.getMaintenanceWindow()).toBeUndefined();
+    });
+  });
+
+  describe('toDDiDto', () => {
+    it('should convert deployment to DDI DTO', () => {
+      const result = deployment.toDDiDto();
+      expect(result.id).toBe(deployment.uuid);
+      expect(result.actionHistory.status).toBe(deployment.state);
+      expect(result.actionHistory.messages).toEqual([]);
+      expect(result.deployment.download).toBe(DownloadUpdateEnum.ATTEMPT);
+      expect(result.deployment.update).toBe(DownloadUpdateEnum.ATTEMPT);
+      expect(result.deployment.maintenanceWindow).toBeUndefined();
+      expect(result.deployment.chunks).toHaveLength(1);
+      const chunk = result.deployment.chunks[0];
+      expect(chunk.part).toBe('');
+      expect(chunk.version).toBe('');
+      expect(chunk.name).toBe('');
+      expect(chunk.artifacts).toEqual([]);
+      expect(chunk.metadata).toEqual([]);
+    });
+
+    it('should handle different deployment states', () => {
+      deployment.state = DeploymentState.FINISHED;
+      let result = deployment.toDDiDto();
+      expect(result.actionHistory.status).toBe(DeploymentState.FINISHED);
+
+      deployment.state = DeploymentState.ERROR;
+      result = deployment.toDDiDto();
+      expect(result.actionHistory.status).toBe(DeploymentState.ERROR);
+
+      deployment.state = DeploymentState.SCHEDULED;
+      result = deployment.toDDiDto();
+      expect(result.actionHistory.status).toBe(DeploymentState.SCHEDULED);
+    });
+  });
+});

--- a/apps/server/src/deployment/entities/deployment.entity.ts
+++ b/apps/server/src/deployment/entities/deployment.entity.ts
@@ -6,9 +6,16 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
   CreateDateColumn,
-  OneToMany,
   ManyToOne,
 } from 'typeorm';
+import { 
+  ActionHistoryDto,
+  ChunkDto,
+  DeploymentDto,
+  DeploymentDDIDto,
+  DownloadUpdateEnum,
+  MaintenanceWindowEnum,
+} from '../../ddi/dtos/deployment-res.dto';
 
 export enum DeploymentState {
   FINISHED = 'finished', // finished successfully
@@ -44,4 +51,47 @@ export class Deployment {
 
   @ManyToOne(() => ImageVersion, (imageVersion) => imageVersion.deployments)
   imageVersion: ImageVersion;
+  
+  getDownloadType(): DownloadUpdateEnum {
+    return DownloadUpdateEnum.ATTEMPT;
+  }
+
+  getUpdateType(): DownloadUpdateEnum {
+    return DownloadUpdateEnum.ATTEMPT;
+  }
+
+  getMaintenanceWindow(): MaintenanceWindowEnum | undefined {
+    return undefined;
+  }
+
+  toDDiDto(): DeploymentDDIDto {
+    const chunkDto = new ChunkDto();
+    chunkDto.part = ''; // TODO
+    chunkDto.version = ''; // TODO
+    chunkDto.name = ''; // TODO
+    chunkDto.artifacts = []; // TODO
+    chunkDto.metadata = [];
+
+    const deploymentDto = new DeploymentDto();
+    deploymentDto.chunks = [
+      chunkDto
+    ];
+    deploymentDto.download = this.getDownloadType()
+    deploymentDto.update = this.getUpdateType()
+    const maintenanceWindow = this.getMaintenanceWindow();
+    if (maintenanceWindow) {
+      deploymentDto.maintenanceWindow = maintenanceWindow;
+    }
+
+    const actionHistoryDto = new ActionHistoryDto();   
+    actionHistoryDto.status = this.state;
+    actionHistoryDto.messages = []; // TODO
+
+    const deploymentDDIDto = new DeploymentDDIDto();
+    deploymentDDIDto.id = this.uuid;
+    deploymentDDIDto.deployment = deploymentDto;
+    deploymentDDIDto.actionHistory = actionHistoryDto;
+     
+    return deploymentDDIDto;
+  }
 }

--- a/apps/server/test/factories/index.ts
+++ b/apps/server/test/factories/index.ts
@@ -44,5 +44,9 @@ export const createMockDeployment = (overrides?: Partial<Deployment>): Deploymen
   updatedAt: new Date('2024-01-01'),
   device: createMockDevice(),
   imageVersion: createMockImageVersion(),
+  getDownloadType: jest.fn(),
+  getUpdateType: jest.fn(),
+  getMaintenanceWindow: jest.fn(),
+  toDDiDto: jest.fn(),
   ...overrides
 });


### PR DESCRIPTION
## Why?

Adds helper methods to get a DDI DTO from a deployment

## How?
- Adds helper methods
- Will need to return when we introduce the artifacts model