### PR TITLE
Adding auth guard to DDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Very much in Alpha.
 - [ ] (DDI) deployment feedback
 - [ ] (DDI) send artifacts
 - [ ] (DDI) send config data
+- [x] (DDI) auth guard
 - [ ] Updating device state
 - [ ] Hardware types and compatibility
 - [ ] Maintain integrity with deletion

--- a/apps/server/src/common/crypto.ts
+++ b/apps/server/src/common/crypto.ts
@@ -1,0 +1,16 @@
+import { randomBytes, createHash as cryptoHash } from 'crypto';
+
+export const createRandomToken = () => randomBytes(16).toString('hex'); // 32 char random string
+
+export const createHash = (algo: 'md5' | 'sha1' | 'sha256', payload: Buffer | string): string => {
+  switch (algo) {
+    case 'md5':
+      return cryptoHash('md5').update(payload).digest('hex');
+    case 'sha1':
+      return cryptoHash('sha1').update(payload).digest('hex');
+    case 'sha256':
+      return cryptoHash('sha256').update(payload).digest('hex');
+    default:
+      throw new Error(`Invalid algorithm: ${algo}`);
+  }
+};

--- a/apps/server/src/ddi/auth.guard.spec.ts
+++ b/apps/server/src/ddi/auth.guard.spec.ts
@@ -1,0 +1,148 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AuthGuard } from './auth.guard';
+import { Device } from '../device/entities/device.entity';
+import { createHash } from '../common/crypto';
+import { createMockDevice } from '../../test/factories';
+
+jest.mock('../common/crypto', () => ({
+  createHash: jest.fn()
+}));
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let deviceRepository: Repository<Device>;
+
+  const mockDevice = createMockDevice();
+  const mockToken = 'valid-token';
+  const mockHashedToken = 'hashed-token';
+
+  const mockDeviceRepository = {
+    findOne: jest.fn()
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthGuard,
+        {
+          provide: getRepositoryToken(Device),
+          useValue: mockDeviceRepository,
+        },
+      ],
+    }).compile();
+
+    guard = module.get<AuthGuard>(AuthGuard);
+    deviceRepository = module.get<Repository<Device>>(getRepositoryToken(Device));
+    jest.clearAllMocks();
+    (createHash as jest.Mock).mockReturnValue(mockHashedToken);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: {
+            authorization: `TargetToken ${mockToken}`
+          }
+        })
+      })
+    } as ExecutionContext;
+
+    it('should return true for valid token and existing device', async () => {
+      mockDeviceRepository.findOne.mockResolvedValue(mockDevice);
+
+      const result = await guard.canActivate(mockExecutionContext);
+
+      expect(result).toBe(true);
+      expect(createHash).toHaveBeenCalledWith('sha256', mockToken);
+      expect(deviceRepository.findOne).toHaveBeenCalledWith({
+        where: { accessToken: mockHashedToken }
+      });
+    });
+
+    it('should return false when authorization header is missing', async () => {
+      const contextWithoutAuth = {
+        switchToHttp: () => ({
+          getRequest: () => ({
+            headers: {}
+          })
+        })
+      } as ExecutionContext;
+
+      const result = await guard.canActivate(contextWithoutAuth);
+
+      expect(result).toBe(false);
+      expect(deviceRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should return false when token type is invalid', async () => {
+      const contextWithInvalidType = {
+        switchToHttp: () => ({
+          getRequest: () => ({
+            headers: {
+              authorization: `Bearer ${mockToken}`
+            }
+          })
+        })
+      } as ExecutionContext;
+
+      const result = await guard.canActivate(contextWithInvalidType);
+
+      expect(result).toBe(false);
+      expect(deviceRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should return false when token format is invalid', async () => {
+      const contextWithInvalidFormat = {
+        switchToHttp: () => ({
+          getRequest: () => ({
+            headers: {
+              authorization: 'TargetToken'  // Missing token part
+            }
+          })
+        })
+      } as ExecutionContext;
+
+      const result = await guard.canActivate(contextWithInvalidFormat);
+
+      expect(result).toBe(false);
+      expect(deviceRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should return false when device is not found', async () => {
+      mockDeviceRepository.findOne.mockResolvedValue(null);
+
+      const result = await guard.canActivate(mockExecutionContext);
+
+      expect(result).toBe(false);
+      expect(createHash).toHaveBeenCalledWith('sha256', mockToken);
+      expect(deviceRepository.findOne).toHaveBeenCalledWith({
+        where: { accessToken: mockHashedToken }
+      });
+    });
+
+    it('should handle malformed authorization header', async () => {
+      const contextWithMalformedHeader = {
+        switchToHttp: () => ({
+          getRequest: () => ({
+            headers: {
+              authorization: 'malformed header'
+            }
+          })
+        })
+      } as ExecutionContext;
+
+      const result = await guard.canActivate(contextWithMalformedHeader);
+
+      expect(result).toBe(false);
+      expect(deviceRepository.findOne).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/ddi/auth.guard.ts
+++ b/apps/server/src/ddi/auth.guard.ts
@@ -1,0 +1,56 @@
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { createHash } from '../common/crypto';
+import { Device } from '../device/entities/device.entity';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  private AUTHORISATION_HEADER = 'authorization';
+  private TARGET_TOKEN_TYPE = 'TargetToken';
+  private readonly logger = new Logger(AuthGuard.name);
+
+  constructor(
+    @InjectRepository(Device)
+    private readonly deviceRepository: Repository<Device>,
+  ) {}
+  
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    return await this.validateRequest(request);
+  }
+
+  private async validateRequest(request: Request) {
+    const token = this.extractToken(request);
+    if(!token) {
+      this.logger.warn('Cannot find access token');
+      return false;
+    }
+    const hashedToken = createHash('sha256', token);
+    const device = await this.findDeviceByToken(hashedToken);
+    if(!device) {
+      this.logger.warn('Cannot find device for access token');
+      return false;
+    }
+    return true;
+  }
+
+  private async findDeviceByToken(token: string): Promise<Device | null> {
+    return await this.deviceRepository.findOne({ where: { accessToken: token } });
+  }
+
+  private extractToken(request: Request): string | null {
+    const authHeader = request.headers[this.AUTHORISATION_HEADER];
+    if (!authHeader) {
+      this.logger.warn('Cannot find authorization header');
+      return null;
+    }
+    const [type, token] = authHeader.split(' ') ?? [];
+    if (type === this.TARGET_TOKEN_TYPE) {
+      this.logger.verbose('Found a target token');
+      return token;
+    }
+    this.logger.warn('Invalid token type');
+    return null;
+  }
+}

--- a/apps/server/src/ddi/ddi.controller.spec.ts
+++ b/apps/server/src/ddi/ddi.controller.spec.ts
@@ -3,7 +3,10 @@ import { DdiController } from './ddi.controller';
 import { DdiService } from './ddi.service';
 import { NotImplementedException, NotFoundException } from '@nestjs/common';
 import { WorkspaceDeviceParams, WorkspaceDeviceDeploymentParams, WorkspaceDeviceImageVersionParams, WorkspaceDeviceImageVersionFilenameParams } from './dtos/path-params.dto';
-import { ConfigDto, LinkDto, LinksDto, PollingConfigDto, RootDto } from './dtos/root-res.dto';
+import { RootDto } from './dtos/root-res.dto';
+import { AuthGuard } from './auth.guard';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Device } from '../device/entities/device.entity';
 
 describe('DdiController', () => {
   let controller: DdiController;
@@ -33,6 +36,10 @@ describe('DdiController', () => {
     downloadArtifactMD5: jest.fn(),
   };
 
+  const mockDeviceRepository = {
+    findOne: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DdiController],
@@ -41,6 +48,11 @@ describe('DdiController', () => {
           provide: DdiService,
           useValue: mockDdiService,
         },
+        {
+          provide: getRepositoryToken(Device),
+          useValue: mockDeviceRepository,
+        },
+        AuthGuard,
       ],
     }).compile();
 

--- a/apps/server/src/ddi/ddi.controller.ts
+++ b/apps/server/src/ddi/ddi.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get, NotImplementedException, Param, Post, Put } from '@nestjs/common';
+import { Controller, Get, NotImplementedException, Param, Post, Put, UseGuards } from '@nestjs/common';
 import { WorkspaceDeviceDeploymentParams, WorkspaceDeviceImageVersionFilenameParams, WorkspaceDeviceImageVersionParams, WorkspaceDeviceParams } from './dtos/path-params.dto';
 import { DdiService } from './ddi.service';
+import { AuthGuard } from './auth.guard';
 
 @Controller('ddi/:workspaceId/controller/v1/:deviceId')
+@UseGuards(AuthGuard)
 export class DdiController {
 
   constructor(

--- a/apps/server/src/device/device.service.ts
+++ b/apps/server/src/device/device.service.ts
@@ -6,6 +6,7 @@ import { Repository } from 'typeorm';
 import { UpdateDeviceDto } from './dtos/update-device.dto';
 import { CreateDeviceDto } from './dtos/create-device.dto';
 import { DEFAULT_POLLING_TIME } from '../common/consts';
+import { createHash, createRandomToken } from '../common/crypto';
 
 @Injectable()
 export class DeviceService {
@@ -23,6 +24,7 @@ export class DeviceService {
     device.pollingTime = DEFAULT_POLLING_TIME;
     device.state = DeviceState.UNKNOWN;
     device.requestConfig = false;
+    device.accessToken = this.createAccessToken();
     this.logger.log(`Creating device: ${device.uuid}`);
     return this.deviceRepository.save(device);
   }
@@ -72,5 +74,11 @@ export class DeviceService {
     device.description = updateDeviceDto.description;
     this.logger.log(`Updating device: ${device.uuid}`);
     return this.deviceRepository.save(device);
+  }
+
+  private createAccessToken(): string {
+    const randomToken = createRandomToken();
+    this.logger.verbose(`Plain text access token: ${randomToken}`);
+    return createHash('sha256', randomToken);
   }
 }

--- a/apps/server/src/device/entities/device.entity.ts
+++ b/apps/server/src/device/entities/device.entity.ts
@@ -37,6 +37,10 @@ export class Device {
   @Column()
   requestConfig: boolean;
 
+  @Exclude()
+  @Column()
+  accessToken: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/apps/server/test/factories/index.ts
+++ b/apps/server/test/factories/index.ts
@@ -10,6 +10,7 @@ export const createMockDevice = (overrides?: Partial<Device>): Device => ({
   state: DeviceState.UNKNOWN,
   pollingTime: '01:00:00',
   requestConfig: false,
+  accessToken: 'access-token-1',
   createdAt: new Date('2024-01-01'),
   updatedAt: new Date('2024-01-01'),
   deployments: [],


### PR DESCRIPTION
## Why?

Protects DDI API with simple token auth

## How?
- Adds hashed token to device with specs and helpers
- Adds auth guard to extracts token and searches for device by it
- Adds specs for auth guard