### PR TITLE
Display associated resources in frontend

### DIFF
--- a/apps/frontend/src/components/TextLink.tsx
+++ b/apps/frontend/src/components/TextLink.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+
+interface TextLinkProps {
+  to: string;
+  children: React.ReactNode;
+}
+
+export const TextLink = ({ to, children }: TextLinkProps) => {
+  return (
+    <Link 
+      to={to}
+      className='text-blue-500 hover:text-blue-700 underline'
+    >
+      {children}
+    </Link>
+  );
+};

--- a/apps/frontend/src/devices/detail.tsx
+++ b/apps/frontend/src/devices/detail.tsx
@@ -15,6 +15,7 @@ import { CreateForm, Field } from '../components/CreateForm';
 import { CreateDialog } from '../components/CreateDialog';
 import { UseFormRegister, UseFormWatch } from 'react-hook-form';
 import { ImageSelect, VersionSelect } from '../components/FormUtils';
+import { TextLink } from '../components/TextLink';
 
 const deviceDetailFields: DetailField<Device>[] = [
   {
@@ -69,6 +70,10 @@ const deploymentColumns: AsyncTableColumn<Deployment>[] = [
   {
     header: 'Created',
     accessor: (deployment) => <DateTime date={deployment.createdAt} />
+  },
+  {
+    header: 'Image',
+    accessor: (deployment) => <TextLink to={`/images/${deployment.imageVersion.image.uuid}`}>{deployment.imageVersion.image.id} ({deployment.imageVersion.id})</TextLink>
   },
 ];
 

--- a/apps/frontend/src/images/index.tsx
+++ b/apps/frontend/src/images/index.tsx
@@ -52,6 +52,10 @@ const imageColumns: AsyncTableColumn<Image>[] = [
     accessor: 'description'
   },
   { 
+    header: 'Versions', 
+    accessor: (image) => image.versions.length
+  },
+  { 
     header: 'Created', 
     accessor: (image) => <DateTime date={image.createdAt} />
   },

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -14,6 +14,7 @@ export interface Image {
   description: string;
   createdAt: string;
   updatedAt: string;
+  versions: ImageVersion[];
 }
 
 export interface CreateDeviceDto {
@@ -43,6 +44,7 @@ export interface Deployment {
   state: string;
   createdAt: string;
   updatedAt: string;
+  imageVersion: ImageVersion;
 }
 
 export interface ImageVersion {
@@ -51,4 +53,5 @@ export interface ImageVersion {
   description: string;
   createdAt: string;
   updatedAt: string;
+  image: Image;
 }

--- a/apps/server/src/device/device.service.spec.ts
+++ b/apps/server/src/device/device.service.spec.ts
@@ -173,7 +173,7 @@ describe('DeviceService', () => {
       expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
       expect(mockRepository.findOne).toHaveBeenLastCalledWith({
         where: { uuid: 'uuid' },
-        relations: ['deployments'],
+        relations: ['deployments', 'deployments.imageVersion', 'deployments.imageVersion.image'],
         relationLoadStrategy: 'query',
       });
     });
@@ -191,7 +191,7 @@ describe('DeviceService', () => {
       expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
       expect(mockRepository.findOne).toHaveBeenLastCalledWith({
         where: { uuid: 'uuid' },
-        relations: ['deployments'],
+        relations: ['deployments', 'deployments.imageVersion', 'deployments.imageVersion.image'],
         relationLoadStrategy: 'query',
       });
     });
@@ -203,7 +203,7 @@ describe('DeviceService', () => {
       expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
       expect(mockRepository.findOne).toHaveBeenLastCalledWith({
         where: { uuid: 'uuid' },
-        relations: ['deployments'],
+        relations: ['deployments', 'deployments.imageVersion', 'deployments.imageVersion.image'],
         relationLoadStrategy: 'query',
       });
     });

--- a/apps/server/src/device/device.service.ts
+++ b/apps/server/src/device/device.service.ts
@@ -49,7 +49,7 @@ export class DeviceService {
   async findDeployments(uuid: string) {
     const device = await this.deviceRepository.findOne({
       where: { uuid },
-      relations: ['deployments'],
+      relations: ['deployments', 'deployments.imageVersion', 'deployments.imageVersion.image'],
       relationLoadStrategy: 'query'
     });
     if (!device) {

--- a/apps/server/src/image/image.service.spec.ts
+++ b/apps/server/src/image/image.service.spec.ts
@@ -76,7 +76,8 @@ describe('ImageService', () => {
       const result = await service.findAll();
       expect(result).toEqual([mockImage]);
       expect(mockRepository.find).toHaveBeenCalledWith({
-        order: { createdAt: 'DESC' }
+        order: { createdAt: 'DESC' },
+        relations: { versions: true }
       });
     });
 

--- a/apps/server/src/image/image.service.ts
+++ b/apps/server/src/image/image.service.ts
@@ -32,6 +32,9 @@ export class ImageService {
     return this.imageRepository.find({
       order: {
         createdAt: 'DESC'
+      },
+      relations: {
+        versions: true
       }
     });
   }


### PR DESCRIPTION
## Why?

Displays links to images in device deployments and display versions of images

## How?
- Adds link components
- Returns associated models from backend