### PR TITLE
Show deployments in image page

### DIFF
--- a/apps/frontend/src/images/detail.tsx
+++ b/apps/frontend/src/images/detail.tsx
@@ -89,7 +89,7 @@ const imageVersionColumns: AsyncTableColumn<ImageVersion>[] = [
 const deploymentColumns: AsyncTableColumn<Deployment>[] = [
   {
     header: 'Version',
-    accessor: (deployment) => deployment.imageVersion.id
+    accessor: (deployment: Deployment) => deployment.imageVersion.id
   },
   { 
     header: 'State', 

--- a/apps/frontend/src/images/detail.tsx
+++ b/apps/frontend/src/images/detail.tsx
@@ -7,7 +7,7 @@ import { ErrorState } from '../components/AsyncUtils';
 import { DateTime } from '../components/DateTime';
 import { DetailView } from '../components/DetailView';
 import { DetailField } from '../components/DetailView';
-import { Image, ImageVersion } from '../types';
+import { Deployment, Image, ImageVersion } from '../types';
 import { AsyncTable, AsyncTableColumn } from '../components/AsyncTable';
 import { CreateForm, Field } from '../components/CreateForm';
 import { CreateDialog } from '../components/CreateDialog';
@@ -16,6 +16,9 @@ import { MAX_ID_LEN } from '../consts';
 import { MIN_ID_LEN } from '../consts';
 import { UseFormRegister } from 'react-hook-form';
 import { CreateImageVersionDto } from '../types';
+import { Pill } from '../components/Pill';
+import { toSentenceCase } from '../utils';
+import { TextLink } from '../components/TextLink';
 
 const imageVersionFields: Field<CreateImageVersionDto>[] = [
   {
@@ -83,6 +86,25 @@ const imageVersionColumns: AsyncTableColumn<ImageVersion>[] = [
   }
 ];
 
+const deploymentColumns: AsyncTableColumn<Deployment>[] = [
+  {
+    header: 'Version',
+    accessor: (deployment) => deployment.imageVersion.id
+  },
+  { 
+    header: 'State', 
+    accessor: (deployment) => <Pill>{toSentenceCase(deployment.state)}</Pill>
+  },
+  {
+    header: 'Device',
+    accessor: (deployment) => <TextLink to={`/devices/${deployment.device.uuid}`}>{deployment.device.id}</TextLink>
+  },
+  {
+    header: 'Created',
+    accessor: (deployment) => <DateTime date={deployment.createdAt} />
+  },
+];
+
 const ImageDetail = () => {
   const { id } = useParams();
 
@@ -120,6 +142,15 @@ const ImageDetail = () => {
             columns={imageVersionColumns}
             emptyMessage='No versions found'
             errorMessage='Error loading versions'
+          />
+        </Card>
+        <Card title='Deployments'>
+          <AsyncTable<Deployment>
+            queryKey={`image-${id}-deployments`}
+            endpoint={`/images/${id}/deployments`}
+            columns={deploymentColumns}
+            emptyMessage='No deployments found'
+            errorMessage='Error loading deployments'
           />
         </Card>
       </Column>

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -44,6 +44,7 @@ export interface Deployment {
   state: string;
   createdAt: string;
   updatedAt: string;
+  device: Device;
   imageVersion: ImageVersion;
 }
 

--- a/apps/server/src/device/device.controller.spec.ts
+++ b/apps/server/src/device/device.controller.spec.ts
@@ -132,7 +132,6 @@ describe('DeviceController', () => {
     });
   });
 
-
   describe('PUT /devices/:uuid', () => {
     const updateDeviceDto: UpdateDeviceDto = {
       id: 'Updated Device',

--- a/apps/server/src/image-version/image-version.controller.ts
+++ b/apps/server/src/image-version/image-version.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
 import { ImageVersionService } from './image-version.service';
 import { ImageVersion } from './entities/image-version.entity';
-import { UUIDParamDto } from '../common/dtos/uuiid-param.dto';
+import { UUIDParamDto } from '../common/dtos/uuid-param.dto';
 import { CreateImageVersionDto } from './dtos/create-image-version.dto';
 import { UpdateImageVersionDto } from './dtos/update-image-version.dto';
 import { MessageDto } from '../common/dtos/message.dto';

--- a/apps/server/src/image/image.controller.ts
+++ b/apps/server/src/image/image.controller.ts
@@ -29,4 +29,10 @@ export class ImageController {
   async update(@Param() params: UUIDParamDto, @Body() updateImageDto: UpdateImageDto) {
     return this.imageService.update(params.uuid, updateImageDto);
   }
+
+  @Get('images/:uuid/deployments')
+  async findDeployments(@Param() params: UUIDParamDto) {
+    return this.imageService.findDeployments(params.uuid);
+  }
+
 }

--- a/apps/server/src/image/image.service.ts
+++ b/apps/server/src/image/image.service.ts
@@ -38,6 +38,26 @@ export class ImageService {
       }
     });
   }
+  async findDeployments(uuid: string) {
+    const image = await this.imageRepository.findOne({
+      where: { uuid },
+      relations: [
+        'versions',
+        'versions.deployments',
+        'versions.deployments.device',
+        'versions.deployments.imageVersion'
+      ],
+      relationLoadStrategy: 'query'
+    });
+    if (!image) {
+      this.logger.error(`Image not found: ${uuid}`);
+      throw new NotFoundException('Image not found');
+    }
+
+    const deployments = image.versions.flatMap(version => version.deployments);
+    return deployments;
+  }
+
 
   async update(uuid: string, updateImageDto: UpdateImageDto): Promise<Image> {
     const image = await this.findImage(uuid);


### PR DESCRIPTION
## Why?

Show list of deployments in image detail page

## How?
- Adds endpoint to fetch all deployments for all versions of an image
- Adds list in frontend in image detail page
- Adds tests
